### PR TITLE
Added EXTRA_DOMAINS option to obtain certs for non sub-domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _Optional settings:_
 * `-e DHLEVEL` - dhparams bit value (default=2048, can be set to `1024` or `4096`)
 * `-p 80` - Port 80 forwarding is optional (cert validation is done through 443)
 * `-e ONLY_SUBDOMAINS` - if you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`
+* `-e EXTRA_DOMAINS` - additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,anotherdomain.org`
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it letsencrypt /bin/bash`.
 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -39,7 +39,7 @@ cp /config/crontabs/* /etc/crontabs/
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
 # shellcheck disable=SC2153
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 fi
 
 # load original config settings
@@ -78,6 +78,16 @@ else
   URLS="-d $URL"
 fi
 
+# add extra domains
+if [ ! -z "$EXTRA_DOMAINS" ]; then
+  echo "EXTRA_DOMAINS entered, processing"
+  for job in $(echo "$EXTRA_DOMAINS" | tr "," " "); do
+    export EXTRA_DOMAINS2="$EXTRA_DOMAINS2 -d ${job}"
+  done
+  echo "Extra domains processed are: $EXTRA_DOMAINS2"
+  URLS="$URLS $EXTRA_DOMAINS2"
+fi
+
 # figuring out whether to use e-mail and which
 if [[ $EMAIL == *@* ]]; then
   echo "E-mail address entered: ${EMAIL}"
@@ -97,7 +107,7 @@ else
 fi
 
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ]; then
   echo "Different sub/domains entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
@@ -122,7 +132,7 @@ else
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 
 # logfiles needed by fail2ban
 [[ ! -f /config/log/nginx/error.log ]] && \


### PR DESCRIPTION
This pull request will allow extra non-subdomains to be added to the the generated certificates without impacting existing installations and resolves https://github.com/linuxserver/docker-letsencrypt/issues/50 in a simple, non-complicated way.

Example Usage:

```
docker create \
    -e "URL=primarydomain.com" \
    -e "SUBDOMAINS=one,two" \
    -e "EXTRA_DOMAINS=secondarydomain.co.uk,tertiarydomain.org" \
    linuxserver/letsencrypt
```