### PR TITLE
Set client_max_body_size 0

### DIFF
--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,4 +1,4 @@
-client_max_body_size 10m;
+client_max_body_size 0;
 client_body_buffer_size 128k;
 
 #Timeout if the real server is dead


### PR DESCRIPTION
Set client_max_body_size 0 so that the proxy.conf doesn't override the nginx.conf. Leaving this as-is causes issues sending data through the proxy


