### PR TITLE
Add php7 soap module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN \
 	php7-pdo_mysql \
 	php7-pdo_sqlite \
 	php7-phar \
+	php7-soap \
 	php7-sockets \
 	php7-tokenizer \
 	php7-xml \

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
++ **04.11.2017:** Add php7 soap module
 + **31.10.2017:** Add php7 exif and xmlreader modules
 + **25.09.2017:** Manage fail2ban via s6
 + **24.09.2017:** Add memcached service


### PR DESCRIPTION
This PR adds the **php-soap module** to the image, installing it through the Dockerfile.