### PR TITLE
Enable Second Certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM lsiobase/alpine.nginx:3.6
-MAINTAINER aptalca
+FROM lsiobase/alpine.nginx:3.7
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+LABEL maintainer="aptalca"
 
 # environment settings
 ENV DHLEVEL=2048 ONLY_SUBDOMAINS=false
@@ -54,13 +54,12 @@ RUN \
 	php7-tokenizer \
 	php7-xml \
 	php7-xmlreader \
-	php7-zip && \
-
-# remove unnecessary fail2ban filters
+	php7-zip \
+	py2-future && \
+ echo "**** remove unnecessary fail2ban filters ****" && \
  rm \
 	/etc/fail2ban/jail.d/alpine-ssh.conf && \
-
-# copy fail2ban default action and filter to /default
+ echo "**** copy fail2ban default action and filter to /default ****" && \
  mkdir -p /defaults/fail2ban && \
  mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
  mv /etc/fail2ban/filter.d /defaults/fail2ban/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM lsiobase/alpine.nginx:3.7
+FROM lsiobase/alpine.nginx:3.6
+MAINTAINER aptalca
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="aptalca"
 
 # environment settings
 ENV DHLEVEL=2048 ONLY_SUBDOMAINS=false
@@ -54,12 +54,13 @@ RUN \
 	php7-tokenizer \
 	php7-xml \
 	php7-xmlreader \
-	php7-zip \
-	py2-future && \
- echo "**** remove unnecessary fail2ban filters ****" && \
+	php7-zip && \
+
+# remove unnecessary fail2ban filters
  rm \
 	/etc/fail2ban/jail.d/alpine-ssh.conf && \
- echo "**** copy fail2ban default action and filter to /default ****" && \
+
+# copy fail2ban default action and filter to /default
  mkdir -p /defaults/fail2ban && \
  mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
  mv /etc/fail2ban/filter.d /defaults/fail2ban/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ _Optional settings:_
 * `-p 80` - Port 80 forwarding is optional (cert validation is done through 443)
 * `-e ONLY_SUBDOMAINS` - if you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`
 * `-e EXTRA_DOMAINS` - additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`
+* `-e CERT2_SUBDOMAINS` - subdomains you'd like the second certificate to cover (comma seperated, no spaces). `blog,wiki,chat`
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it letsencrypt /bin/bash`.
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 _Optional settings:_
 * `-e EMAIL` - your e-mail address for cert registration and notifications
 * `-e DHLEVEL` - dhparams bit value (default=2048, can be set to `1024` or `4096`)
-* `-p 80` - Port 80 forwarding is optional (cert validation is done through 443)
+* `-p 80` - Port 80 forwarding is optional (cert validation is done through 443 by default) unless the `HTTPVAL` option is set to `true`
 * `-e ONLY_SUBDOMAINS` - if you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`
 * `-e EXTRA_DOMAINS` - additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`
 * `-e CERT2_SUBDOMAINS` - subdomains you'd like the second certificate to cover (comma seperated, no spaces). `blog,wiki,chat`
+* `-e HTTPVAL` - if you wish to get certs through http validation on port 80 instead of port 443, set this to `true`. Keep in mind that you also have to map port 80 as listed above
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it letsencrypt /bin/bash`.
 
@@ -76,6 +77,7 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 * Before running this container, make sure that the url and subdomains are properly forwarded to this container's host, and that port 443 is not being used by another service on the host (NAS gui, another webserver, etc.).
 * Port 443 on the internet side of the router should be forwarded to this container's port 443 (Required for letsencrypt validation)
+* If `HTTPVAL` is set to `true`, port 80 on the internet side of the router should be forwarded to this container's port 80 (Required for letsencrypt validation)
 * `--cap-add=NET_ADMIN` is required for fail2ban to modify iptables
 * If you need a dynamic dns provider, you can use the free provider duckdns.org where the url will be `yoursubdomain.duckdns.org` and the subdomains can be `www,ftp,cloud`
 * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. It also detects changes to the DHLEVEL parameter and replaces the dhparams file.
@@ -97,25 +99,29 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
-+ **04.11.2017:** Add php7 soap module
-+ **31.10.2017:** Add php7 exif and xmlreader modules
-+ **25.09.2017:** Manage fail2ban via s6
-+ **24.09.2017:** Add memcached service
-+ **01.09.2017:** `--privileged` is no longer required as long as `--cap-add=NET_ADMIN` is added, instructions modified accordingly, disabled fail2ban ipv6 actions due to requiring access to host kernel modules
-+ **31.08.2017:** Add php7-phar
-+ **14.07.2017:** Enable modules dynamically in nginx.conf
-+ **06.07.2017:** Add support for multiple domains (thanks @oznu)
-+ **22.06.2017:** Add various nginx modules and enable all modules in the default nginx.conf
-+ **16.06.2017:** Update deprecated certbot option for https validation, make e-mail entry optional, update readme
-+ **05.06.2017:** Add php7-bz2
-+ **27.05.2017:** Rebase to alpine 3.6.
-+ **03.05.2017:** Fix log permissions.
-+ **18.04.2017:** Add php7-sockets, update fail2ban filter and action defaults
-+ **27.02.2017:** Add php7-dom, php7-iconv and php7-pdo_sqlite
-+ **21.02.2017:** Add php7-xml
-+ **10.02.2017:** Switch to alpine 3.5 base and php7, add php zlib module and all nginx modules
-+ **13.01.2017:** Add php5-ctype and php5-openssl
-+ **04.01.2017:** Add php5-mysqli and php5-pdo_mysql
-+ **22.11.2016:** Add gd and mcrypt packages
-+ **21.11.2016:** Add curl package
-+ **07.11.2016:** Initial Release
++ **11.01.18:** Halt the container if validation fails instead of a stop (so restart=always doesn't get users throttled with letsencrypt)
++ **10.01.18:** Add option for http validation on port 80
++ **05.01.18:** Rebase to alpine 3.7
++ **05.12.17:** Added option for second certificate for different subdomains
++ **04.11.17:** Add php7 soap module
++ **31.10.17:** Add php7 exif and xmlreader modules
++ **25.09.17:** Manage fail2ban via s6
++ **24.09.17:** Add memcached service
++ **01.09.17:** `--privileged` is no longer required as long as `--cap-add=NET_ADMIN` is added, instructions modified accordingly, disabled fail2ban ipv6 actions due to requiring access to host kernel modules
++ **31.08.17:** Add php7-phar
++ **14.07.17:** Enable modules dynamically in nginx.conf
++ **06.07.17:** Add support for multiple domains (thanks @oznu)
++ **22.06.17:** Add various nginx modules and enable all modules in the default nginx.conf
++ **16.06.17:** Update deprecated certbot option for https validation, make e-mail entry optional, update readme
++ **05.06.17:** Add php7-bz2
++ **27.05.17:** Rebase to alpine 3.6.
++ **03.05.17:** Fix log permissions.
++ **18.04.17:** Add php7-sockets, update fail2ban filter and action defaults
++ **27.02.17:** Add php7-dom, php7-iconv and php7-pdo_sqlite
++ **21.02.17:** Add php7-xml
++ **10.02.17:** Switch to alpine 3.5 base and php7, add php zlib module and all nginx modules
++ **13.01.17:** Add php5-ctype and php5-openssl
++ **04.01.17:** Add php5-mysqli and php5-pdo_mysql
++ **22.11.16:** Add gd and mcrypt packages
++ **21.11.16:** Add curl package
++ **07.11.16:** Initial Release

--- a/README.md
+++ b/README.md
@@ -54,11 +54,10 @@ http://192.168.x.x:8080 would show you what's running INSIDE the container on po
 _Optional settings:_
 * `-e EMAIL` - your e-mail address for cert registration and notifications
 * `-e DHLEVEL` - dhparams bit value (default=2048, can be set to `1024` or `4096`)
-* `-p 80` - Port 80 forwarding is optional (cert validation is done through 443 by default) unless the `HTTPVAL` option is set to `true`
+* `-p 80` - Port 80 forwarding is optional (cert validation is done through 443)
 * `-e ONLY_SUBDOMAINS` - if you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`
 * `-e EXTRA_DOMAINS` - additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`
 * `-e CERT2_SUBDOMAINS` - subdomains you'd like the second certificate to cover (comma seperated, no spaces). `blog,wiki,chat`
-* `-e HTTPVAL` - if you wish to get certs through http validation on port 80 instead of port 443, set this to `true`. Keep in mind that you also have to map port 80 as listed above
 
 It is based on alpine linux with s6 overlay, for shell access whilst the container is running do `docker exec -it letsencrypt /bin/bash`.
 
@@ -77,7 +76,6 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 * Before running this container, make sure that the url and subdomains are properly forwarded to this container's host, and that port 443 is not being used by another service on the host (NAS gui, another webserver, etc.).
 * Port 443 on the internet side of the router should be forwarded to this container's port 443 (Required for letsencrypt validation)
-* If `HTTPVAL` is set to `true`, port 80 on the internet side of the router should be forwarded to this container's port 80 (Required for letsencrypt validation)
 * `--cap-add=NET_ADMIN` is required for fail2ban to modify iptables
 * If you need a dynamic dns provider, you can use the free provider duckdns.org where the url will be `yoursubdomain.duckdns.org` and the subdomains can be `www,ftp,cloud`
 * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. It also detects changes to the DHLEVEL parameter and replaces the dhparams file.
@@ -99,29 +97,25 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
-+ **11.01.18:** Halt the container if validation fails instead of a stop (so restart=always doesn't get users throttled with letsencrypt)
-+ **10.01.18:** Add option for http validation on port 80
-+ **05.01.18:** Rebase to alpine 3.7
-+ **05.12.17:** Added option for second certificate for different subdomains
-+ **04.11.17:** Add php7 soap module
-+ **31.10.17:** Add php7 exif and xmlreader modules
-+ **25.09.17:** Manage fail2ban via s6
-+ **24.09.17:** Add memcached service
-+ **01.09.17:** `--privileged` is no longer required as long as `--cap-add=NET_ADMIN` is added, instructions modified accordingly, disabled fail2ban ipv6 actions due to requiring access to host kernel modules
-+ **31.08.17:** Add php7-phar
-+ **14.07.17:** Enable modules dynamically in nginx.conf
-+ **06.07.17:** Add support for multiple domains (thanks @oznu)
-+ **22.06.17:** Add various nginx modules and enable all modules in the default nginx.conf
-+ **16.06.17:** Update deprecated certbot option for https validation, make e-mail entry optional, update readme
-+ **05.06.17:** Add php7-bz2
-+ **27.05.17:** Rebase to alpine 3.6.
-+ **03.05.17:** Fix log permissions.
-+ **18.04.17:** Add php7-sockets, update fail2ban filter and action defaults
-+ **27.02.17:** Add php7-dom, php7-iconv and php7-pdo_sqlite
-+ **21.02.17:** Add php7-xml
-+ **10.02.17:** Switch to alpine 3.5 base and php7, add php zlib module and all nginx modules
-+ **13.01.17:** Add php5-ctype and php5-openssl
-+ **04.01.17:** Add php5-mysqli and php5-pdo_mysql
-+ **22.11.16:** Add gd and mcrypt packages
-+ **21.11.16:** Add curl package
-+ **07.11.16:** Initial Release
++ **04.11.2017:** Add php7 soap module
++ **31.10.2017:** Add php7 exif and xmlreader modules
++ **25.09.2017:** Manage fail2ban via s6
++ **24.09.2017:** Add memcached service
++ **01.09.2017:** `--privileged` is no longer required as long as `--cap-add=NET_ADMIN` is added, instructions modified accordingly, disabled fail2ban ipv6 actions due to requiring access to host kernel modules
++ **31.08.2017:** Add php7-phar
++ **14.07.2017:** Enable modules dynamically in nginx.conf
++ **06.07.2017:** Add support for multiple domains (thanks @oznu)
++ **22.06.2017:** Add various nginx modules and enable all modules in the default nginx.conf
++ **16.06.2017:** Update deprecated certbot option for https validation, make e-mail entry optional, update readme
++ **05.06.2017:** Add php7-bz2
++ **27.05.2017:** Rebase to alpine 3.6.
++ **03.05.2017:** Fix log permissions.
++ **18.04.2017:** Add php7-sockets, update fail2ban filter and action defaults
++ **27.02.2017:** Add php7-dom, php7-iconv and php7-pdo_sqlite
++ **21.02.2017:** Add php7-xml
++ **10.02.2017:** Switch to alpine 3.5 base and php7, add php zlib module and all nginx modules
++ **13.01.2017:** Add php5-ctype and php5-openssl
++ **04.01.2017:** Add php5-mysqli and php5-pdo_mysql
++ **22.11.2016:** Add gd and mcrypt packages
++ **21.11.2016:** Add curl package
++ **07.11.2016:** Initial Release

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -39,7 +39,7 @@ cp /config/crontabs/* /etc/crontabs/
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
 # shellcheck disable=SC2153
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGHTTPVAL=\"$HTTPVAL\"" > /config/donoteditthisfile.conf
 fi
 
 # load original config settings
@@ -117,6 +117,13 @@ else
   EMAILPARAM="--register-unsafely-without-email"
 fi
 
+# setting the validation method to use
+if [ "$HTTPVAL" = "true" ]; then
+  PREFCHAL="http"
+else
+  PREFCHAL="tls-sni"
+fi
+
 # setting the symlink for key location
 rm -rf /config/keys/letsencrypt
 if [ "$ONLY_SUBDOMAINS" = "true" ]; then
@@ -137,7 +144,7 @@ else
 fi
 
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$HTTPVAL" = "$ORIGHTTPVAL" ]; then
   echo "Different sub/domains entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
@@ -163,8 +170,13 @@ fi
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   echo "Generating new Cert 1 certificate"
 # shellcheck disable=SC2086
-  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $URLS
-  cd /config/keys/letsencrypt || exit
+  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URLS
+  if [ -d /config/keys/letsencrypt ]; then
+    cd /config/keys/letsencrypt || exit
+  else
+    echo "ERROR: Cert does not exist! Please see the validation error above. The issue may be due to incorrect dns or port forwarding settings. Please fix your settings and recreate the container"
+    sleep infinity
+  fi
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
   chmod +x /app/le-renew.sh
@@ -176,7 +188,7 @@ fi
 if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
   echo "Generating new Cert 2 certificate"
 # shellcheck disable=SC2086
-  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URLS
+  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URLS
   cd /config/keys/letsencrypt2 || exit
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
@@ -184,7 +196,7 @@ else
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGHTTPVAL=\"$HTTPVAL\"" > /config/donoteditthisfile.conf
 
 # logfiles needed by fail2ban
 [[ ! -f /config/log/nginx/error.log ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -39,7 +39,7 @@ cp /config/crontabs/* /etc/crontabs/
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
 # shellcheck disable=SC2153
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGHTTPVAL=\"$HTTPVAL\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 fi
 
 # load original config settings
@@ -117,13 +117,6 @@ else
   EMAILPARAM="--register-unsafely-without-email"
 fi
 
-# setting the validation method to use
-if [ "$HTTPVAL" = "true" ]; then
-  PREFCHAL="http"
-else
-  PREFCHAL="tls-sni"
-fi
-
 # setting the symlink for key location
 rm -rf /config/keys/letsencrypt
 if [ "$ONLY_SUBDOMAINS" = "true" ]; then
@@ -144,7 +137,7 @@ else
 fi
 
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$HTTPVAL" = "$ORIGHTTPVAL" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ]; then
   echo "Different sub/domains entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
@@ -170,13 +163,8 @@ fi
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   echo "Generating new Cert 1 certificate"
 # shellcheck disable=SC2086
-  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URLS
-  if [ -d /config/keys/letsencrypt ]; then
-    cd /config/keys/letsencrypt || exit
-  else
-    echo "ERROR: Cert does not exist! Please see the validation error above. The issue may be due to incorrect dns or port forwarding settings. Please fix your settings and recreate the container"
-    sleep infinity
-  fi
+  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $URLS
+  cd /config/keys/letsencrypt || exit
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
   chmod +x /app/le-renew.sh
@@ -188,7 +176,7 @@ fi
 if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
   echo "Generating new Cert 2 certificate"
 # shellcheck disable=SC2086
-  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URLS
+  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URLS
   cd /config/keys/letsencrypt2 || exit
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
@@ -196,7 +184,7 @@ else
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGHTTPVAL=\"$HTTPVAL\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 
 # logfiles needed by fail2ban
 [[ ! -f /config/log/nginx/error.log ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -39,7 +39,7 @@ cp /config/crontabs/* /etc/crontabs/
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
 # shellcheck disable=SC2153
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 fi
 
 # load original config settings
@@ -72,10 +72,30 @@ if [ ! -z "$SUBDOMAINS" ]; then
   else
     URLS="-d ${URL}${SUBDOMAINS2}"
   fi
-  echo "Sub-domains processed are: $SUBDOMAINS2"
+  echo "Sub-domains processed for certificate 1 are: $SUBDOMAINS2"
 else
   echo "No subdomains defined"
   URLS="-d $URL"
+fi
+
+#Edit for Second Certificate
+# figuring out url only vs url & subdomains vs subdomains only
+if [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  echo "CERT2_SUBDOMAINS entered, processing"
+  for job in $(echo "$CERT2_SUBDOMAINS" | tr "," " "); do
+    export CERT2_SUBDOMAINS2="$CERT2_SUBDOMAINS2 -d ${job}.${URL}"
+  done
+  if [ "$ONLY_SUBDOMAINS" = true ]; then
+    CERT2_URLS="$CERT2_SUBDOMAINS2"
+    echo "Only subdomains, no URL in cert"
+  else
+    #CERT2_URLS="-d ${URL}${CERT2_SUBDOMAINS2}"
+    #not tested. Don't imagine this would work.
+    echo "Root URL in certificate, set Only subdomains to TRUE to generate a second certificate"
+  fi
+  echo "Sub-domains processed for certificate 2 are: $CERT2_SUBDOMAINS2"
+else
+  echo "No subdomains for Certificate 2 defined"
 fi
 
 # add extra domains
@@ -106,22 +126,42 @@ else
   ln -s ../etc/letsencrypt/live/"$URL" /config/keys/letsencrypt
 fi
 
+#Edit for second Certificate
+# setting the symlink for key2 location
+rm -rf /config/keys/letsencrypt2
+if [ "$ONLY_SUBDOMAINS" = "true" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  CERT2_DOMAIN="$(echo "$CERT2_SUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${URL}"
+  ln -s ../etc/letsencrypt/live/"$CERT2_DOMAIN" /config/keys/letsencrypt2
+else
+  echo "Conditions for second certificate not set, not generating letsencrypt2 directory"
+fi
+
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ]; then
   echo "Different sub/domains entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
+    #Edit for more verbose logging
+    echo "Cert 1 Revoked"
+    CERT2_ORIGDOMAIN="$(echo "$CERT2_ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+    certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
+    echo "Cert 2 Revoked"
+    
   else
     certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
+    #Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
+    echo "Cert 1 Revoked - Root Domain"
   fi
   rm -rf /config/etc
   mkdir -p /config/etc/letsencrypt
+else
+  echo "no changes detected"
 fi
 
 # generating certs if necessary
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
-  echo "Generating new certificate"
+  echo "Generating new Cert 1 certificate"
 # shellcheck disable=SC2086
   certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $URLS
   cd /config/keys/letsencrypt || exit
@@ -132,8 +172,19 @@ else
   /app/le-renew.sh
 fi
 
+#Edit to Generate Second Certificate if necessary
+if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  echo "Generating new Cert 2 certificate"
+# shellcheck disable=SC2086
+  certbot certonly --non-interactive --renew-by-default --standalone --preferred-challenges tls-sni --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URLS
+  cd /config/keys/letsencrypt2 || exit
+  openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
+else
+  sleep 1
+fi
+
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\"" > /config/donoteditthisfile.conf
 
 # logfiles needed by fail2ban
 [[ ! -f /config/log/nginx/error.log ]] && \


### PR DESCRIPTION
I made some changes so that I could maintain two separate certificates for a different set of subdomains. Perhaps some others would like to do the same. This code will only create a second certificate if:
1. only use subdomains is true
2. CERT2_SUBDOMAINS contains a list