### PR TITLE
cp -u instead of cp -n

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -14,7 +14,8 @@ rm -rf /etc/letsencrypt
 ln -s /config/etc/letsencrypt /etc/letsencrypt
 
 # copy dns default configs
-cp -n /defaults/dns-conf/* /config/dns-conf/
+[[ ! -d /config/dns-conf ]] && \
+cp -u /defaults/dns-conf/* /config/dns-conf/
 
 # copy/update the fail2ban config defaults to/in /config
 cp -R /defaults/fail2ban/filter.d /config/fail2ban/


### PR DESCRIPTION
the option `cp -n` on alpine seems non-existent
something similar will be `cp -u`

```
Usage: cp [OPTIONS] SOURCE... DEST
Copy SOURCE(s) to DEST
        -a      Same as -dpR
        -R,-r   Recurse
        -d,-P   Preserve symlinks (default if -R)
        -L      Follow all symlinks
        -H      Follow symlinks on command line
        -p      Preserve file attributes if possible
        -f      Overwrite
        -i      Prompt before overwrite
        -l,-s   Create (sym)links
        -u      Copy only newer files
```