### PR TITLE
Add Support for Second Certificate for specified subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ _Optional settings:_
 * `-e EXTRA_DOMAINS` - additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`
 * `-e STAGING` - set to `true` to retrieve certs in staging mode. Rate limits will be much higher, but the resulting cert will not pass the browser's security test. Only to be used for testing purposes.
 * `-e HTTPVAL` - Deprecated, please use the `VALIDATION` parameter instead
+* `-e CERT2_SUBDOMAINS` - subdomains you'd like the second certificate to cover (comma seperated, no spaces). `blog,wiki,chat`
 
 _Important notice:_
 * This image previously used tls-sni validation over port 443. However, due to a security vulnerability, letsencrypt disabled tls-sni validation: https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188 If you are getting the following error in the log, that means you are attempting tls-sni authentication, which is disabled by the servers: `Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA.` Please set the `VALIDATION` parameter to either `http` or `dns` and follow the above directions to revalidate. 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -218,10 +218,6 @@ CERT1REV="false"
 CERT2REV="false"
 ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
 CERT2_ORIGDOMAIN="$(echo "$CERT2_ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
-echo "Orig Domain:"
-echo "$ORIGDOMAIN"
-echo "cert 2 ORIGDOMAIN"
-echo "$CERT2_ORIGDOMAIN"
 
 #Popwebz - Block edited to add second certificate
 # checking for changes in cert variables, revoking certs if necessary
@@ -314,10 +310,7 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   fi
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
-  echo "Certificate exists; parameters unchanged; attempting renewal"
-  chmod +x /app/le-renew.sh
   sleep 1
-  /app/le-renew.sh
 fi
 
 #Popwebz - Block added to add second certificate
@@ -338,7 +331,10 @@ if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAI
   fi
   openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 else
+  echo "Certificates exists. Attempting renewal"
+  chmod +x /app/le-renew.sh
   sleep 1
+  /app/le-renew.sh
 fi
 #Popwebz - end added block to add second certificate
 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -224,11 +224,11 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" 
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
     #Popwebz - Edit for more verbose logging
-    echo "Cert 1 Revoked (subdomains unchanged)"
+    echo "Cert 1 Revoked (other parameters changed)"
 
     #Popwebz - Edit to also revoke Cert 2
     [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
-    echo "Cert 2 Revoked (subdomains unchanged)"
+    echo "Cert 2 Revoked (other parameters changed)"
     #Popwebz end edit
 
     #set vars to not repeat Revoke
@@ -238,7 +238,7 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" 
   else
     [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
      #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
-    echo "Cert 1 Revoked - Root Domain (subdomains unchanged)"
+    echo "Cert 1 Revoked - Root Domain (other parameters changed)"
     #Popwebz end edit
     CERT1REV="true"
 
@@ -248,13 +248,13 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" 
   mkdir -p /config/etc/letsencrypt2 #popwebz edit to add folder -p for no error if already existing
 
   else
-  echo "no certificate changes required"
+  echo "no certificate changes required (unless subdomains changed)"
 fi
 
 
 #Popwebz logic to only revoke what is needed
 
- if [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT1REV" = "false" ]; then
+ if [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT1REV" = "true" ]; then
    if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
      ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
      [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
@@ -263,12 +263,12 @@ fi
    else
      [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
       #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
-     echo "Cert 1 Revoked - Root Domain (subdomains unchanged)"
+     echo "Cert 1 Revoked - Root Domain (subdomains changed)"
    fi
 fi
 
- if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$CERT2REV" = "false" ]; then
- [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
+ if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$CERT2REV" = "true" ]; then
+ [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGSUBDOMAINS"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
   echo "Cert 2 Revoked (subdomains changed)"
 fi
 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -278,22 +278,19 @@ fi
 
 #Delete live folders after revoking
 if [ "$CERT1REV" = "true" ]; then
-  rm -rf /config/etc/letsencrypt/keys
-  rm -rf /config/etc/letsencrypt/csr
-  rm -rf /config/etc/letsencrypt/accounts
-  rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"*
-  rm -f /config/etc/letsencrypt/renewal/"$ORIGDOMAIN"*
+#  rm -rf /config/etc/letsencrypt/keys
+ # rm -rf /config/etc/letsencrypt/csr
+  #rm -rf /config/etc/letsencrypt/accounts
+#  rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"*
+ # rm -f /config/etc/letsencrypt/renewal/"$ORIGDOMAIN"*
+ rm -rf /config/etc
   echo "Live Cert 1 folder deleted"
   sleep 4
   mkdir -p /config/etc/letsencrypt
 fi
 
 if [ "$CERT2REV" = "true" ]; then
-  rm -rf /config/etc/letsencrypt/keys
-  rm -rf /config/etc/letsencrypt/csr
-  rm -rf /config/etc/letsencrypt/accounts
-  rm -rf /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"
-  rm -f /config/etc/letsencrypt/renewal/"$CERT2_ORIGDOMAIN"*
+  rm -rf /config/etc
   echo "Live Cert 2 folder deleted"
   sleep 4
   mkdir -p /config/etc/letsencrypt

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -282,12 +282,14 @@ fi
 
 #Delete live folders after revoking
 if [ "$CERT1REV" = "true" ]; then
-  rm -rf /config/etc/"$ORIGDOMAIN"
+  rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"
+  echo "Live Cert 1 folder deleted"
   mkdir -p /config/etc/letsencrypt
 fi
 
 if [ "$CERT2REV" = "true" ]; then
-  rm -rf /config/etc/"$CERT2_ORIGDOMAIN"
+  rm -rf /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"
+  echo "Live Cert 2 folder deleted"
   mkdir -p /config/etc/letsencrypt
 fi
 

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -216,19 +216,25 @@ fi
 #Initialize revocation tracking variables
 CERT1REV="false"
 CERT2REV="false"
+ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+CERT2_ORIGDOMAIN="$(echo "$CERT2_ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+echo "Orig Domain:"
+echo "$ORIGDOMAIN"
+echo "cert 2 ORIGDOMAIN"
+echo "$CERT2_ORIGDOMAIN"
 
 #Popwebz - Block edited to add second certificate
 # checking for changes in cert variables, revoking certs if necessary
 if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
   echo "Different validation parameters entered than what was used before. Revoking and deleting existing Cert 1 certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
-    ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+    
     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
     #Popwebz - Edit for more verbose logging
     echo "Cert 1 Revoked (other parameters changed)"
 
     #Popwebz - Edit to also revoke Cert 2
-    CERT2_ORIGDOMAIN="$(echo "$CERT2_ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+    
     [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
     echo "Cert 2 Revoked (other parameters changed)"
     #Popwebz end edit

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -278,14 +278,22 @@ fi
 
 #Delete live folders after revoking
 if [ "$CERT1REV" = "true" ]; then
-  rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"
+  rm -rf /config/etc/letsencrypt/keys
+  rm -rf /config/etc/letsencrypt/csr
+  rm -rf /config/etc/letsencrypt/accounts
+  rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"*
+  rm -f /config/etc/letsencrypt/renewal/"$ORIGDOMAIN"*
   echo "Live Cert 1 folder deleted"
   sleep 4
   mkdir -p /config/etc/letsencrypt
 fi
 
 if [ "$CERT2REV" = "true" ]; then
+  rm -rf /config/etc/letsencrypt/keys
+  rm -rf /config/etc/letsencrypt/csr
+  rm -rf /config/etc/letsencrypt/accounts
   rm -rf /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"
+  rm -f /config/etc/letsencrypt/renewal/"$CERT2_ORIGDOMAIN"*
   echo "Live Cert 2 folder deleted"
   sleep 4
   mkdir -p /config/etc/letsencrypt

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -213,6 +213,7 @@ else
 fi
 #Popwebz - end added block to add second certificate
 
+#Initialize revocation tracking variables
 CERT1REV="false"
 CERT2REV="false"
 
@@ -227,6 +228,7 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" 
     echo "Cert 1 Revoked (other parameters changed)"
 
     #Popwebz - Edit to also revoke Cert 2
+    CERT2_ORIGDOMAIN="$(echo "$CERT2_ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
     echo "Cert 2 Revoked (other parameters changed)"
     #Popwebz end edit
@@ -243,9 +245,6 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" 
     CERT1REV="true"
 
   fi
-  rm -rf /config/etc
-  mkdir -p /config/etc/letsencrypt
-  mkdir -p /config/etc/letsencrypt2 #popwebz edit to add folder -p for no error if already existing
 
   else
   echo "no certificate changes required (unless subdomains changed)"
@@ -254,9 +253,8 @@ fi
 
 #Popwebz logic to only revoke what is needed
 
- if [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT1REV" = "true" ]; then
+ if [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ "$CERT1REV" = "true" ]; then
    if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
-     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
      [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
      #Popwebz - Edit for more verbose logging
      echo "Cert 1 Revoked (subdomains changed)"
@@ -265,14 +263,29 @@ fi
       #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
      echo "Cert 1 Revoked - Root Domain (subdomains changed)"
    fi
+   #set tracking var
+   CERT1REV="true"
 fi
 
- if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$CERT2REV" = "true" ]; then
- [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGSUBDOMAINS"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
+ if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ "$CERT2REV" = "true" ]; then
+ [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
   echo "Cert 2 Revoked (subdomains changed)"
+  #set tracking var
+  CERT2REV="true"
 fi
 
-# saving new variables
+#Delete live folders after revoking
+if [ "$CERT1REV" = "true" ]; then
+  rm -rf /config/etc/"$ORIGDOMAIN"
+  mkdir -p /config/etc/letsencrypt
+fi
+
+if [ "$CERT2REV" = "true" ]; then
+  rm -rf /config/etc/"$CERT2_ORIGDOMAIN"
+  mkdir -p /config/etc/letsencrypt
+fi
+
+# saving new variables to file
 echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\"  CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\"" > /config/donoteditthisfile.conf
 
 # generating certs if necessary

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -147,7 +147,7 @@ if [ ! -z "$CERT2_SUBDOMAINS" ]; then
     export CERT2_SUBDOMAINS_REAL="$CERT2_SUBDOMAINS_REAL -d ${job}.${URL}"
   done
   if [ "$ONLY_SUBDOMAINS" = true ]; then
-    CERT2_URLS="$CERT2_SUBDOMAINS_REAL"
+    CERT2_URL_REAL="$CERT2_SUBDOMAINS_REAL"
     echo "Only subdomains, no URL in cert"
   else
     echo "Root URL in certificate, set Only subdomains to TRUE to generate a second certificate"
@@ -213,28 +213,34 @@ else
 fi
 #Popwebz - end added block to add second certificate
 
+CERT1REV="false"
+CERT2REV="false"
+
 #Popwebz - Block edited to add second certificate
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
   echo "Different validation parameters entered than what was used before. Revoking and deleting existing Cert 1 certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
-
     #Popwebz - Edit for more verbose logging
-    echo "Cert 1 (Subdomains) Revoked"
+    echo "Cert 1 Revoked (other parameters changed)"
 
     #Popwebz - Edit to also revoke Cert 2
-    if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ]; then
     [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
-    echo "Cert 2 (Subdomains) Revoked"
+    echo "Cert 2 Revoked (other parameters changed)"
     #Popwebz end edit
+
+    #set vars to not repeat Revoke
+    CERT1REV="true"
+    CERT2REV="true"
 
   else
     [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
      #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
-    echo "Cert 1 Revoked - Root Domain"
+    echo "Cert 1 Revoked - Root Domain (other parameters changed)"
     #Popwebz end edit
+    CERT1REV="true"
 
   fi
   rm -rf /config/etc
@@ -242,7 +248,28 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "
   mkdir -p /config/etc/letsencrypt2 #popwebz edit to add folder -p for no error if already existing
 
   else
-  echo "no certificate changes required"
+  echo "no certificate changes required (unless subdomains changed)"
+fi
+
+
+#Popwebz logic to only revoke what is needed
+
+ if [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT1REV" = "true" ]; then
+   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
+     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
+     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
+     #Popwebz - Edit for more verbose logging
+     echo "Cert 1 Revoked (subdomains changed)"
+   else
+     [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
+      #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
+     echo "Cert 1 Revoked - Root Domain (subdomains changed)"
+   fi
+fi
+
+ if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$CERT2REV" = "true" ]; then
+ [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGSUBDOMAINS"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
+  echo "Cert 2 Revoked (subdomains changed)"
 fi
 
 # saving new variables
@@ -277,7 +304,7 @@ fi
 if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
   echo "Generating new Cert 2 certificate"
 # shellcheck disable=SC2086
-  certbot certonly --renew-by-default $PREFCHAL $STGNG --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+  certbot certonly --renew-by-default $PREFCHAL $STGNG --rsa-key-size 4096 $EMAILPARAM --agree-tos $CERT2_URL_REAL
   if [ -d /config/keys/letsencrypt2 ]; then
     cd /config/keys/letsencrypt2 || exit
   else

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -72,11 +72,13 @@ cp /config/fail2ban/jail.local /etc/fail2ban/jail.local
 rm /etc/crontabs/*
 cp /config/crontabs/* /etc/crontabs/
 
+#Popwebz - Block edited to add second certificate
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\" CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\"" > /config/donoteditthisfile.conf
   echo "Created donoteditthisfile.conf"
 fi
+#Popwebz - End block edit
 
 # load original config settings
 # shellcheck disable=SC1091
@@ -130,11 +132,31 @@ if [ ! -z "$SUBDOMAINS" ]; then
   else
     URL_REAL="-d ${URL}${SUBDOMAINS_REAL}"
   fi
-  echo "Sub-domains processed are: $SUBDOMAINS_REAL"
+  #Popwebz - Block edited to add second certificate
+  echo "Sub-domains processed for certificate 1 are: $SUBDOMAINS_REAL"
 else
   echo "No subdomains defined"
   URL_REAL="-d $URL"
 fi
+
+#Popwebz - Block edited to add second certificate
+# figuring out url only vs url & subdomains vs subdomains only
+if [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  echo "CERT2_SUBDOMAINS entered, processing"
+  for job in $(echo "$CERT2_SUBDOMAINS" | tr "," " "); do
+    export CERT2_SUBDOMAINS_REAL="$CERT2_SUBDOMAINS_REAL -d ${job}.${URL}"
+  done
+  if [ "$ONLY_SUBDOMAINS" = true ]; then
+    CERT2_URLS="$CERT2_SUBDOMAINS_REAL"
+    echo "Only subdomains, no URL in cert"
+  else
+    echo "Root URL in certificate, set Only subdomains to TRUE to generate a second certificate"
+  fi
+  echo "Sub-domains processed for certificate 2 are: $CERT2_SUBDOMAINS_REAL"
+else
+  echo "No subdomains for Certificate 2 defined"
+fi
+#Popwebz - End edit to add second certificate
 
 # add extra domains
 if [ ! -z "$EXTRA_DOMAINS" ]; then
@@ -180,25 +202,53 @@ else
   ln -s ../etc/letsencrypt/live/"$URL" /config/keys/letsencrypt
 fi
 
+#Popwebz - Block added to add second certificate
+# setting the symlink for key2 location
+rm -rf /config/keys/letsencrypt2
+if [ "$ONLY_SUBDOMAINS" = "true" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  CERT2_DOMAIN="$(echo "$CERT2_SUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${URL}"
+  ln -s ../etc/letsencrypt/live/"$CERT2_DOMAIN" /config/keys/letsencrypt2
+else
+  echo "Conditions for second certificate not set, not generating letsencrypt2 directory"
+fi
+#Popwebz - end added block to add second certificate
+
+#Popwebz - Block edited to add second certificate
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
   echo "Different validation parameters entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
+    
+    #Popwebz - Edit for more verbose logging
+    echo "Cert 1 Revoked"
+    #Popwebz - Edit to also revoke Cert 2
+    [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
+    echo "Cert 2 Revoked"
+    #Popwebz end edit
+    
   else
     [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
+     #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
+    echo "Cert 1 Revoked - Root Domain"
+    #Popwebz end edit
+    
   fi
   rm -rf /config/etc
   mkdir -p /config/etc/letsencrypt
+  
+  else
+  echo "no changes detected"
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\"  CERT2_ORIGSUBDOMAINS=\"$CERT2_SUBDOMAINS\"" > /config/donoteditthisfile.conf
 
 # generating certs if necessary
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
-  echo "Generating new certificate"
+#Popwebz Edit line below to clarify that it is cert 1
+  echo "Generating new Cert 1 certificate"
  # shellcheck disable=SC2086
  certbot certonly --renew-by-default $PREFCHAL $STGNG --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
   if [ -d /config/keys/letsencrypt ]; then
@@ -218,6 +268,28 @@ else
   sleep 1
   /app/le-renew.sh
 fi
+
+#Popwebz - Block added to add second certificate
+#Edit to Generate Second Certificate if necessary
+if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
+  echo "Generating new Cert 2 certificate"
+# shellcheck disable=SC2086
+  certbot certonly --renew-by-default $PREFCHAL $STGNG --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+  if [ -d /config/keys/letsencrypt2 ]; then
+    cd /config/keys/letsencrypt2 || exit
+  else
+    if [ "$VALIDATION" = "dns" ]; then
+      echo "ERROR: Cert does not exist! Please see the validation error above. Make sure you entered correct credentials into the /config/dns-conf/${DNSPLUGIN}.ini file."
+    else
+      echo "ERROR: Cert does not exist! Please see the validation error above. The issue may be due to incorrect dns or port forwarding settings. Please fix your settings and recreate the container"
+    fi
+    sleep infinity
+  fi
+  openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
+else
+  sleep 1
+fi
+#Popwebz - end added block to add second certificate
 
 # logfiles needed by fail2ban
 [[ ! -f /config/log/nginx/error.log ]] && \

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -215,31 +215,34 @@ fi
 
 #Popwebz - Block edited to add second certificate
 # checking for changes in cert variables, revoking certs if necessary
-if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
-  echo "Different validation parameters entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
+if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$STAGING" = "$ORIGSTAGING" ]; then
+  echo "Different validation parameters entered than what was used before. Revoking and deleting existing Cert 1 certificate, and an updated one will be created"
   if [ "$ORIGONLY_SUBDOMAINS" = "true" ]; then
     ORIGDOMAIN="$(echo "$ORIGSUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${ORIGURL}"
     [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem
-    
+
     #Popwebz - Edit for more verbose logging
-    echo "Cert 1 Revoked"
+    echo "Cert 1 (Subdomains) Revoked"
+
     #Popwebz - Edit to also revoke Cert 2
+    if [ ! "$CERT2_SUBDOMAINS" = "$CERT2_ORIGSUBDOMAINS" ]; then
     [[ -f /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"/fullchain.pem
-    echo "Cert 2 Revoked"
+    echo "Cert 2 (Subdomains) Revoked"
     #Popwebz end edit
-    
+
   else
     [[ -f /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem ]] && certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGURL"/fullchain.pem
      #Popwebz Note: no need to revoke if not originally set to only subdomains, as that is not done with a root certificate
     echo "Cert 1 Revoked - Root Domain"
     #Popwebz end edit
-    
+
   fi
   rm -rf /config/etc
   mkdir -p /config/etc/letsencrypt
-  
+  mkdir -p /config/etc/letsencrypt2 #popwebz edit to add folder -p for no error if already existing
+
   else
-  echo "no changes detected"
+  echo "no certificate changes required"
 fi
 
 # saving new variables
@@ -270,7 +273,7 @@ else
 fi
 
 #Popwebz - Block added to add second certificate
-#Edit to Generate Second Certificate if necessary
+#Edit to Generate Second Certificate if necessary (cert file misssing and cer2 subdomains specified)
 if [ ! -f "/config/keys/letsencrypt2/fullchain.pem" ] && [ ! -z "$CERT2_SUBDOMAINS" ]; then
   echo "Generating new Cert 2 certificate"
 # shellcheck disable=SC2086

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -280,12 +280,14 @@ fi
 if [ "$CERT1REV" = "true" ]; then
   rm -rf /config/etc/letsencrypt/live/"$ORIGDOMAIN"
   echo "Live Cert 1 folder deleted"
+  sleep 4
   mkdir -p /config/etc/letsencrypt
 fi
 
 if [ "$CERT2REV" = "true" ]; then
   rm -rf /config/etc/letsencrypt/live/"$CERT2_ORIGDOMAIN"
   echo "Live Cert 2 folder deleted"
+  sleep 4
   mkdir -p /config/etc/letsencrypt
 fi
 


### PR DESCRIPTION
Rebased code to support second certificate with CERT2_SUBDOMAINS variable. I have thoroughly tested my changes and updates with a docker build (you can view my dockerhub) that is working and live on my personal unraid server.

This is my suggested pull request from earlier. I like the idea of having two different certificates on my server for a different set of subdomains.

I could not figure out how to update my pull request from earlier so that my changes could easily be seen. Doing a rebase attached myself to all 84 commits that were made since I last made the pull request. If the team has suggestions in that regard, please let me know.

I hope others will find this useful, it would be great if this could be merged as maintaining a separate branch is time consuming.