### PR TITLE
added working syncthing subdomain proxy .conf template for linuxserver.io syncthing docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
++ **25.07.18:** Add subdomain proxy conf for syncthing
 + **23.07.18:** Remove backwards compatibility and set default validation method to http. Update portainer proxy config to fix websockets. Add unifi proxy conf.
 + **31.05.18:** Update ssl.conf and proxy.conf for tighter security (thanks @nemchik)
 + **30.05.18:** Add reverse proxy configs for jackett, monitorr, nzbget, nzbhydra, organizr, portainer and transmission (thanks @nemchik)

--- a/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
@@ -1,0 +1,22 @@
+# sample subdomain proxy-conf for linuxserver.io sycnthing (not tested with other dockers)
+# should work out of the box if sycnthing is installed properly on same interface using default ports
+# to enable password access, uncomment the two auth_basic lines
+
+server {
+    listen 443 ssl;
+
+    server_name syncthing.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    location / {
+#       auth_basic "Restricted";
+#       auth_basic_user_file /config/nginx/.htpasswd;
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_syncthing syncthing;
+        proxy_pass http://$upstream_syncthing:8384;
+    }
+}

--- a/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
@@ -1,5 +1,4 @@
-# sample subdomain proxy-conf for linuxserver.io sycnthing (not tested with other dockers)
-# should work out of the box if sycnthing is installed properly on same interface using default ports
+# make sure that your dns has a cname set for syncthing and that your syncthing container is not using a base url
 # to enable password access, uncomment the two auth_basic lines
 
 server {


### PR DESCRIPTION
added working syncthing subdomain proxy .conf template for linuxserver.io syncthing docker

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

