### PR TITLE
working subfolder proxy .conf for qBittorrent

### DIFF
--- a/root/defaults/proxy-confs/jdownloader2.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/jdownloader2.subdomain.conf.sample
@@ -1,0 +1,27 @@
+# make sure that your dns has a cname set for jdownloader2
+# serves jdownloader2 container at jd2.yourdomain.tld
+# to enable password access, uncomment the two auth_basic lines
+
+server {
+    listen 443 ssl;
+
+    server_name jd2.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+	location / {
+	    proxy_pass http://192.168.1.50:7807;
+#		auth_basic "Restricted";
+#		auth_basic_user_file /config/nginx/.htpasswd;
+        include /config/nginx/proxy.conf;
+	}
+
+	location /websockify {
+		proxy_pass http://192.168.1.50:7807;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_read_timeout 86400;
+	}
+}

--- a/root/defaults/proxy-confs/plex.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/plex.subfolder.conf.sample
@@ -1,0 +1,13 @@
+# sample conf for linuxserver.io plex docker. access at "yourdomain/web" (breaks functionality if the url is changed from "/web")
+# please change the proxy_pass I.P. to the I.P. your plex docker is running on in default 'host' mode
+# to enable password access, uncomment the two auth_basic lines
+
+location ^~ /web {
+    auth_basic "Restricted";
+    auth_basic_user_file /config/nginx/.htpasswd;
+	include /config/nginx/proxy.conf;
+    proxy_pass http://192.168.1.50:32400;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}

--- a/root/defaults/proxy-confs/qbittorrent.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/qbittorrent.subfolder.conf.sample
@@ -1,0 +1,21 @@
+# qBittorrent devs on Github indicated the Origin and Referer headers needed to be surpressed,
+# and that the X-Forwarded-Host needed to match what was seen in the browser,
+# as of version 4.0.3 these are the working settings.
+
+# Note: For some users, several windows in the Web UI may still be blank, such as the main GUI page when adding
+# a new torrent from a URL/magnet or local file.
+# If so, uncomment the last line "add_header" and restart the webserver
+
+# to enable password access, uncomment the two auth_basic lines
+
+location /qbt/ {
+#   auth_basic "Restricted";
+#   auth_basic_user_file /config/nginx/.htpasswd;
+    proxy_pass              http://192.168.1.50:8080/;
+    proxy_set_header        X-Forwarded-Host        $server_name:$server_port;
+    proxy_hide_header       Referer;
+    proxy_hide_header       Origin;
+    proxy_set_header        Referer                 '';
+    proxy_set_header        Origin                  '';
+#   add_header              X-Frame-Options         "SAMEORIGIN";
+}

--- a/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
@@ -1,4 +1,4 @@
-# make sure that your dns has a cname set for syncthing and that your syncthing container is not using a base url
+# make sure you have a cname set for sycnthing in your dns
 # to enable password access, uncomment the two auth_basic lines
 
 server {

--- a/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
@@ -1,14 +1,15 @@
 # thelounge does not require a base url setting
+# serves thelounge at yourdomain.tld/irc
 # to enable password access, uncomment the two auth_basic lines
 
 location ^~ /irc/ {
-    auth_basic "Restricted";
-    auth_basic_user_file /config/nginx/.htpasswd;
-	proxy_pass http://192.168.1.50:9000/;
-	proxy_http_version 1.1;
-	proxy_set_header Connection "upgrade";
-	proxy_set_header Upgrade $http_upgrade;
-	proxy_set_header X-Forwarded-For $remote_addr;
+#		auth_basic "Restricted";
+#		auth_basic_user_file /config/nginx/.htpasswd;
+		proxy_pass http://192.168.1.50:9000/;
+		proxy_http_version 1.1;
+		proxy_set_header Connection "upgrade";
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header X-Forwarded-For $remote_addr;
 
 	# by default nginx times out connections in one minute
 	proxy_read_timeout 1d;

--- a/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
@@ -1,0 +1,15 @@
+# thelounge does not require a base url setting
+# to enable password access, uncomment the two auth_basic lines
+
+location ^~ /irc/ {
+    auth_basic "Restricted";
+    auth_basic_user_file /config/nginx/.htpasswd;
+	proxy_pass http://192.168.1.50:9000/;
+	proxy_http_version 1.1;
+	proxy_set_header Connection "upgrade";
+	proxy_set_header Upgrade $http_upgrade;
+	proxy_set_header X-Forwarded-For $remote_addr;
+
+	# by default nginx times out connections in one minute
+	proxy_read_timeout 1d;
+}

--- a/root/defaults/proxy-confs/ubooquity.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/ubooquity.subfolder.conf.sample
@@ -1,0 +1,21 @@
+# ubooquity uses 2 different ports for webUI access. 2202 for library access and 2203 for admin panel access
+# serves the library at yourdomain.tld/library and admin panel at yourdomain.tld/library/admin
+# to enable password access, uncomment the two auth_basic lines
+
+location /library {
+#    auth_basic "Restricted";
+#    auth_basic_user_file /config/nginx/.htpasswd;
+	proxy_pass http://192.168.1.50:2202/library;
+	proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+
+location /library/admin {
+#    auth_basic "Restricted";
+#    auth_basic_user_file /config/nginx/.htpasswd;
+	proxy_pass http://192.168.1.50:2203/library/admin;
+	proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}


### PR DESCRIPTION
working subfolder proxy .conf for qBittorrent with all additional settings to prevent blank page load and redirect issues. Works with qBittorrent 4.1.1

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

