### PR TITLE
Add optional header to prevent search indexing

### DIFF
--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -32,3 +32,4 @@ ssl_stapling_verify on;
 #add_header X-UA-Compatible "IE=Edge" always;
 #add_header Cache-Control "no-transform" always;
 #add_header Referrer-Policy "same-origin" always;
+#add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";


### PR DESCRIPTION
This is probably a good thing to have and for most people running homeservers to enable so that any pages that are detected by a search engine don't end up getting indexed.

Could potentially help with issues like this https://www.reddit.com/r/Tautulli/comments/98aoz3/help_hackers_how_do_i_securehide_my_tautulli/ although I am not positive that the method that was used to discover this user's website was via search engine. Still a fun story to read and take precautions.