### PR TITLE
Add optional baseurls to subdomain proxy confs

### DIFF
--- a/root/defaults/proxy-confs/radarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/radarr.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,8 +26,8 @@ server {
         set $upstream_radarr radarr;
         proxy_pass http://$upstream_radarr:7878;
     }
-    
-    location ^~ /api {
+
+    location ^~ (/radarr)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_radarr radarr;

--- a/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,8 +26,8 @@ server {
         set $upstream_sabnzbd sabnzbd;
         proxy_pass http://$upstream_sabnzbd:8080;
     }
-    
-    location ^~ /api {
+
+    location ^~ (/sabnzbd)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_sabnzbd sabnzbd;

--- a/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,8 +26,8 @@ server {
         set $upstream_sonarr sonarr;
         proxy_pass http://$upstream_sonarr:8989;
     }
-    
-    location ^~ /api {
+
+    location ^~ (/sonarr)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_sonarr sonarr;

--- a/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,8 +26,8 @@ server {
         set $upstream_tautulli tautulli;
         proxy_pass http://$upstream_tautulli:8181;
     }
-    
-    location ^~ /api {
+
+    location ^~ (/tautulli)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_tautulli tautulli;


### PR DESCRIPTION
For apps with API blocks the baseurl may possibly exist if a user is using both subdomain and subfolder at the same time (I do this). Adding these little bits allows to the subdomain blocks with API locations makes them work both with and without a baseurl on subdomains.