### PR TITLE
Add rpc locations for transmission proxies

### DIFF
--- a/root/defaults/proxy-confs/transmission.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/transmission.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -21,6 +21,13 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_transmission transmission;
+        proxy_pass http://$upstream_transmission:9091;
+    }
+
+    location ^~ (/transmission)?/rpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_transmission transmission;

--- a/root/defaults/proxy-confs/transmission.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/transmission.subfolder.conf.sample
@@ -14,3 +14,10 @@ location /transmission {
     set $upstream_transmission transmission;
     proxy_pass http://$upstream_transmission:9091;
 }
+
+location ^~ /transmission/rpc {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_transmission transmission;
+    proxy_pass http://$upstream_transmission:9091;
+}


### PR DESCRIPTION
This is essentially the same thing as the api blocks that were recently added to Sonarr/Radarr.

I've included the proposed change for api with optional baseurl in #170