### PR TITLE
Remove commented example proxies from default

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -22,7 +22,7 @@ server {
 
 	# all ssl related config moved to ssl.conf
 	include /config/nginx/ssl.conf;
-	
+
 	# enable for ldap auth
 	#include /config/nginx/ldap.conf;
 
@@ -42,68 +42,7 @@ server {
 		include /etc/nginx/fastcgi_params;
 	}
 
-# sample reverse proxy config for password protected couchpotato running at IP 192.168.1.50 port 5050 with base url "cp"
-# notice this is within the same server block as the base
-# don't forget to generate the .htpasswd file as described on docker hub
-#	location ^~ /cp {
-#		auth_basic "Restricted";
-#		auth_basic_user_file /config/nginx/.htpasswd;
-#		include /config/nginx/proxy.conf;
-#		proxy_pass http://192.168.1.50:5050/cp;
-#	}
-
 }
-
-# sample reverse proxy config without url base, but as a subdomain "cp", ip and port same as above
-# notice this is a new server block, you need a new server block for each subdomain
-#server {
-#	listen 443 ssl;
-#
-#	root /config/www;
-#	index index.html index.htm index.php;
-#
-#	server_name cp.*;
-#
-#	include /config/nginx/ssl.conf;
-#
-#	client_max_body_size 0;
-#
-#	location / {
-#		auth_basic "Restricted";
-#		auth_basic_user_file /config/nginx/.htpasswd;
-#		include /config/nginx/proxy.conf;
-#		proxy_pass http://192.168.1.50:5050;	
-#	}
-#}
-
-# sample reverse proxy config for "heimdall" via subdomain, with ldap authentication
-# ldap-auth container has to be running and the /config/nginx/ldap.conf file should be filled with ldap info
-# notice this is a new server block, you need a new server block for each subdomain
-#server {
-#	listen 443 ssl;
-#
-#	root /config/www;
-#	index index.html index.htm index.php;
-#
-#	server_name heimdall.*;
-#
-#	include /config/nginx/ssl.conf;
-#
-#	include /config/nginx/ldap.conf;
-#
-#	client_max_body_size 0;
-#
-#	location / {
-#		# the next two lines will enable ldap auth along with the included ldap.conf in the server block
-#		auth_request /auth;
-#		error_page 401 =200 /login;
-#
-#		include /config/nginx/proxy.conf;
-#		resolver 127.0.0.11 valid=30s;
-#		set $upstream_heimdall heimdall;
-#		proxy_pass https://$upstream_heimdall:443;
-#	}
-#}
 
 # enable subdomain method reverse proxy confs
 include /config/nginx/proxy-confs/*.subdomain.conf;


### PR DESCRIPTION
Do these make sense to still be here? The sample proxy-confs seem to serve the same purpose. These comments also seem to use actual IP addresses for the cp examples, and upstream variables for heimdall. Also the cp examples here conflict with the included couchpotato subdomain and subfolder proxy-conf samples using `/cp` as baseurl instead of `/couchpotato`.

These comments may still have value, but I think they would be better explained in their respective files (which is mostly already done).