### PR TITLE
Move php conf to separate file

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -22,7 +22,7 @@ server {
 
 	# all ssl related config moved to ssl.conf
 	include /config/nginx/ssl.conf;
-	
+
 	# enable for ldap auth
 	#include /config/nginx/ldap.conf;
 
@@ -30,13 +30,7 @@ server {
 
 	location / {
 		try_files $uri $uri/ /index.html /index.php?$args =404;
-	}
-
-	location ~ \.php$ {
-		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-		fastcgi_pass 127.0.0.1:9000;
-		fastcgi_index index.php;
-		include /etc/nginx/fastcgi_params;
+		include /config/nginx/php.conf;
 	}
 
 # sample reverse proxy config for password protected couchpotato running at IP 192.168.1.50 port 5050 with base url "cp"
@@ -69,7 +63,7 @@ server {
 #		auth_basic "Restricted";
 #		auth_basic_user_file /config/nginx/.htpasswd;
 #		include /config/nginx/proxy.conf;
-#		proxy_pass http://192.168.1.50:5050;	
+#		proxy_pass http://192.168.1.50:5050;
 #	}
 #}
 

--- a/root/defaults/php.conf
+++ b/root/defaults/php.conf
@@ -1,0 +1,7 @@
+location ~ \.php$ {
+  try_files $uri =404;
+  fastcgi_split_path_info ^(.+\.php)(/.+)$;
+  fastcgi_pass 127.0.0.1:9000;
+  fastcgi_index index.php;
+  include /etc/nginx/fastcgi_params;
+}


### PR DESCRIPTION
This ties to #174 
I have moved the php conf to a separate file and included that file inside the `/` location. Any other location that needs php can easily include the same file. This should negate the need to comment out the php conf when using rutorrent.