### PR TITLE
adjusted pid path

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -2,7 +2,7 @@
 
 user abc;
 worker_processes 4;
-pid /run/nginx.pid;
+pid /var/run/nginx.pid;
 include /etc/nginx/modules/*.conf;
 
 events {


### PR DESCRIPTION
The default location for the nginx pid is  `--pid-path=/var/run/nginx.pid ` but nginx.conf sets it as /run/nginx.pid. This results in an error when running nginx -t. `nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)`
