### PR TITLE
Fixes for api locations

### DIFF
--- a/root/defaults/proxy-confs/jackett.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/jackett.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_jackett:9117;
     }
 
-    location ^~ (/jackett)?/api {
+    location ~ (/jackett)?/(api|dl) {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_jackett jackett;

--- a/root/defaults/proxy-confs/jackett.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/jackett.subfolder.conf.sample
@@ -15,7 +15,7 @@ location /jackett {
     proxy_pass http://$upstream_jackett:9117;
 }
 
-location ^~ /jackett/api {
+location ~ /jackett/(api|dl) {
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
     set $upstream_jackett jackett;

--- a/root/defaults/proxy-confs/nzbhydra.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/nzbhydra.subdomain.conf.sample
@@ -26,4 +26,11 @@ server {
         set $upstream_nzbhydra hydra2;
         proxy_pass http://$upstream_nzbhydra:5076;
     }
+
+    location ~ (/nzbhydra)?/api {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_nzbhydra hydra2;
+        proxy_pass http://$upstream_nzbhydra:5076;
+    }
 }

--- a/root/defaults/proxy-confs/nzbhydra.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/nzbhydra.subfolder.conf.sample
@@ -14,3 +14,10 @@ location /nzbhydra {
     set $upstream_nzbhydra hydra2;
     proxy_pass http://$upstream_nzbhydra:5076;
 }
+
+location ^~ /nzbhydra/api {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_nzbhydra hydra2;
+    proxy_pass http://$upstream_nzbhydra:5076;
+}

--- a/root/defaults/proxy-confs/radarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/radarr.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_radarr:7878;
     }
 
-    location ^~ (/radarr)?/api {
+    location ~ (/radarr)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_radarr radarr;

--- a/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_sabnzbd:8080;
     }
 
-    location ^~ (/sabnzbd)?/api {
+    location ~ (/sabnzbd)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_sabnzbd sabnzbd;

--- a/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_sonarr:8989;
     }
 
-    location ^~ (/sonarr)?/api {
+    location ~ (/sonarr)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_sonarr sonarr;

--- a/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_tautulli:8181;
     }
 
-    location ^~ (/tautulli)?/api {
+    location ~ (/tautulli)?/api {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_tautulli tautulli;

--- a/root/defaults/proxy-confs/transmission.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/transmission.subdomain.conf.sample
@@ -27,7 +27,7 @@ server {
         proxy_pass http://$upstream_transmission:9091;
     }
 
-    location ^~ (/transmission)?/rpc {
+    location ~ (/transmission)?/rpc {
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_transmission transmission;


### PR DESCRIPTION
The locations below use regex and my previous commit left the "not regex" location indicator. Also jackett uses `/api` and `/dl`. Lastly, Hydra uses an API location as well.