### PR TITLE
Add rutorrent subdomain proxy sample

### DIFF
--- a/root/defaults/proxy-confs/rutorrent.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/rutorrent.subdomain.conf.sample
@@ -1,0 +1,36 @@
+# make sure that your dns has a cname set for rutorrent
+
+server {
+    listen 443 ssl;
+
+    server_name rutorrent.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_rutorrent rutorrent;
+        proxy_pass http://$upstream_rutorrent:80;
+    }
+
+    location /RPC2 {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_rutorrent rutorrent;
+        proxy_pass http://$upstream_rutorrent:80;
+    }
+}


### PR DESCRIPTION
This one does NOT include the optional subfolder/baseurl for the RPC2 location because rutorrent does not actually use a subfolder/baseurl and this was accomplished with an nginx rewrite for the subfolder conf. the RPC2 location is still included for the purpose of avoiding auth and allowing apps to communicate without nginx auth.