### PR TITLE
Add Ombi swagger api proxy configs

### DIFF
--- a/root/defaults/proxy-confs/ombi.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/ombi.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,4 +26,14 @@ server {
         set $upstream_ombi ombi;
         proxy_pass http://$upstream_ombi:3579;
     }
+
+    location ~ (/ombi)?/swagger {
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_ombi ombi;
+        proxy_pass http://$upstream_ombi:3579;
+   }
+   if ($http_referer ~* /ombi) {
+       rewrite ^/swagger/(.*) /ombi/swagger/$1? redirect;
+   }
 }

--- a/root/defaults/proxy-confs/ombi.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/ombi.subfolder.conf.sample
@@ -19,6 +19,12 @@ location ^~ /ombi/ {
     proxy_pass http://$upstream_ombi:3579;
 }
 
-if ($http_referer ~* /ombi/) {
-    rewrite ^/dist/(.*) $scheme://$host/ombi/dist/$1 permanent;
+location ^~ /ombi/swagger {
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_ombi ombi;
+    proxy_pass http://$upstream_ombi:3579;
+}
+if ($http_referer ~* /ombi) {
+    rewrite ^/swagger/(.*) /ombi/swagger/$1? redirect;
 }


### PR DESCRIPTION
The rewrite that was removed is no longer needed (hasn't been for a while) and wasn't in the subdomain conf anyway.

The stuff added is for ombi's swagger api.