### PR TITLE
Add pihole proxy config samples

### DIFF
--- a/root/defaults/proxy-confs/pihole.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/pihole.subdomain.conf.sample
@@ -1,0 +1,44 @@
+# make sure that your dns has a cname set for pihole and that your pihole container is not using a base url
+
+server {
+    listen 443 ssl;
+
+    server_name pihole.*;
+
+    include /config/nginx/ssl.conf;
+
+    client_max_body_size 0;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/ldap.conf;
+
+    location / {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_pihole pihole;
+        proxy_pass http://$upstream_pihole:80;
+    }
+
+    location /admin {
+        # enable the next two lines for http auth
+        #auth_basic "Restricted";
+        #auth_basic_user_file /config/nginx/.htpasswd;
+
+        # enable the next two lines for ldap auth
+        #auth_request /auth;
+        #error_page 401 =200 /login;
+
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_pihole pihole;
+        proxy_pass http://$upstream_pihole:80;
+    }
+}

--- a/root/defaults/proxy-confs/pihole.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/pihole.subfolder.conf.sample
@@ -1,0 +1,39 @@
+# pihole does not require a base url setting
+
+location /pihole {
+    return 301 $scheme://$host/pihole/;
+}
+location ^~ /pihole/ {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    #auth_request /auth;
+    #error_page 401 =200 /login;
+
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_pihole pihole;
+    rewrite /pihole(.*) $1 break;
+    proxy_pass http://$upstream_pihole:80;
+}
+
+location /pihole/admin {
+    return 301 $scheme://$host/pihole/admin/;
+}
+location ^~ /pihole/admin/ {
+    # enable the next two lines for http auth
+    #auth_basic "Restricted";
+    #auth_basic_user_file /config/nginx/.htpasswd;
+
+    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    #auth_request /auth;
+    #error_page 401 =200 /login;
+
+    include /config/nginx/proxy.conf;
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_pihole pihole;
+    rewrite /pihole(.*) $1 break;
+    proxy_pass http://$upstream_pihole:80;
+}


### PR DESCRIPTION
This one was tricky at first. The `/admin` location is actually kind of the primary focus with pihole but the `/` location is still important. Both of the locations may or may not require auth which is why i've got what seems like duplicated configs here.