### PR TITLE
Add trailing slash to bazarr comment

### DIFF
--- a/root/defaults/proxy-confs/bazarr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/bazarr.subfolder.conf.sample
@@ -1,4 +1,4 @@
-# first go into bazarr settings, under "General" set the URL Base to /bazarr and restart the bazarr container
+# first go into bazarr settings, under "General" set the URL Base to /bazarr/ and restart the bazarr container
 
 location /bazarr {
     return 301 $scheme://$host/bazarr/;


### PR DESCRIPTION
Bazarr needs a trailing slash in its settings. The config works, I've just added the trailing slash to the comment.