### PR TITLE
Add Organizr Auth config

### DIFF
--- a/root/defaults/auth-confs/ldap.conf
+++ b/root/defaults/auth-confs/ldap.conf
@@ -1,4 +1,4 @@
-## Version 2018/08/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ldap.conf
+## Version 2018/08/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/auth-confs/ldap.conf
 ## this conf is meant to be used in conjuntction with our ldap-auth image: https://github.com/linuxserver/docker-ldap-auth
 ## see the heimdall example in the default site config for info on enabling ldap auth
 ## for further instructions on this conf, see https://github.com/nginxinc/nginx-ldap-auth

--- a/root/defaults/auth-confs/organizr.conf
+++ b/root/defaults/auth-confs/organizr.conf
@@ -1,0 +1,35 @@
+## Version 2018/10/11 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/auth-confs/organizr.conf
+## this conf is meant to be used in conjuntction with organizr: https://organizr.app/
+
+    location ~ /auth-(admin|user) {
+        # This is used for Organizr V1
+        internal;
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_organizr organizr;
+        proxy_pass http://$upstream_organizr:80/auth.php?$1;
+        proxy_set_header Content-Length "";
+
+        # Do not uncomment the lines below, these are examples for usue in other proxy configs
+        #auth_request /auth-admin;   #=Admin
+        #auth_request /auth-user;    #=User
+    }
+
+    location ~ /auth-([0-9]+) {
+        # This is used for Organizr V2
+        internal;
+        include /config/nginx/proxy.conf;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream_organizr organizr;
+        proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
+        proxy_set_header Content-Length "";
+
+        # Do not uncomment the lines below, these are examples for usue in other proxy configs
+        #auth_request /auth-0;   #=Admin
+        #auth_request /auth-1;   #=Co-Admin
+        #auth_request /auth-2;   #=Super User
+        #auth_request /auth-3;   #=Power User
+        #auth_request /auth-4;   #=User
+        #auth_request /auth-998; #=Logged In
+        #auth_request /auth-999; #=Guest
+    }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -22,9 +22,9 @@ server {
 
 	# all ssl related config moved to ssl.conf
 	include /config/nginx/ssl.conf;
-	
+
 	# enable for ldap auth
-	#include /config/nginx/ldap.conf;
+	#include /config/nginx/auth-confs/ldap.conf;
 
 	client_max_body_size 0;
 
@@ -69,7 +69,7 @@ server {
 #		auth_basic "Restricted";
 #		auth_basic_user_file /config/nginx/.htpasswd;
 #		include /config/nginx/proxy.conf;
-#		proxy_pass http://192.168.1.50:5050;	
+#		proxy_pass http://192.168.1.50:5050;
 #	}
 #}
 
@@ -86,7 +86,7 @@ server {
 #
 #	include /config/nginx/ssl.conf;
 #
-#	include /config/nginx/ldap.conf;
+#	include /config/nginx/auth-confs/ldap.conf;
 #
 #	client_max_body_size 0;
 #

--- a/root/defaults/proxy-confs/airsonic.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/airsonic.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /airsonic {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/bazarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/bazarr.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/bazarr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/bazarr.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /bazarr/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/couchpotato.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/couchpotato.subdomain.conf.sample
@@ -9,8 +9,8 @@ server {
 
     client_max_body_size 0;
 
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/couchpotato.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/couchpotato.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /couchpotato {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/deluge.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/deluge.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/deluge.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/deluge.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /deluge/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/flood.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/flood.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/flood.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/flood.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /flood/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/headphones.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/headphones.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/headphones.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/headphones.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /headphones {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/heimdall.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/heimdall.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/jackett.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/jackett.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/jackett.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/jackett.subfolder.conf.sample
@@ -5,7 +5,7 @@ location /jackett {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/lazylibrarian.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/lazylibrarian.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/lazylibrarian.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/lazylibrarian.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /lazylibrarian {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/lidarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/lidarr.subdomain.conf.sample
@@ -9,8 +9,8 @@ server {
 
     client_max_body_size 0;
 
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/lidarr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/lidarr.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /lidarr {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/medusa.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/medusa.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/medusa.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/medusa.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /medusa {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/monitorr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/monitorr.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/monitorr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/monitorr.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /monitorr {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/mylar.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/mylar.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/mylar.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/mylar.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /mylar {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/netdata.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/netdata.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/netdata.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/netdata.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /netdata/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/nzbget.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/nzbget.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/nzbget.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/nzbget.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /nzbget {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/nzbhydra.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/nzbhydra.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/nzbhydra.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/nzbhydra.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /nzbhydra {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/ombi.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/ombi.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/ombi.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/ombi.subfolder.conf.sample
@@ -9,7 +9,7 @@ location ^~ /ombi/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/organizr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/organizr.subdomain.conf.sample
@@ -10,7 +10,10 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
+
+    # enable for organizr auth
+    #include /config/nginx/auth-confs/organizr.conf;
 
     location / {
         # enable the next two lines for http auth
@@ -21,29 +24,16 @@ server {
         #auth_request /auth;
         #error_page 401 =200 /login;
 
+        # enable the next two lines for organizr auth
+        #auth_request /auth-*; # See auth-confs/organizr.conf for proper config
+        #error_page 401 /?error=$status&return=$request_uri;
+
         include /config/nginx/proxy.conf;
         resolver 127.0.0.11 valid=30s;
         set $upstream_organizr organizr;
         proxy_pass http://$upstream_organizr:80;
     }
 
-    location ~ /auth-(admin|user) {
-        # This is used for Organizr V1
-        internal;
-        include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
-        set $upstream_organizr organizr;
-        proxy_pass http://$upstream_organizr:80/auth.php?$1;
-        proxy_set_header Content-Length "";
-    }
-
-    location ~ /auth-([0-9]+) {
-        # This is used for Organizr V2
-        internal;
-        include /config/nginx/proxy.conf;
-        resolver 127.0.0.11 valid=30s;
-        set $upstream_organizr organizr;
-        proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
-        proxy_set_header Content-Length "";
-    }
+    # enable for custom error pages
+    #error_page 400 403 404 405 408 500 502 503 504 /?error=$status;
 }

--- a/root/defaults/proxy-confs/organizr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/organizr.subfolder.conf.sample
@@ -1,13 +1,20 @@
 # In order to use this location block you need to edit the default file one folder up and comment out the / location
 
+# enable for organizr auth
+#include /config/nginx/auth-confs/organizr.conf;
+
 location / {
     # enable the next two lines for http auth
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
+
+    # enable the next two lines for organizr auth, also enable auth-confs/organizr.conf in proxy-confs/organizr.subfolder.conf
+    #auth_request /auth-*; # See auth-confs/organizr.conf for proper config
+    #error_page 401 /?error=$status&return=$request_uri;
 
     include /config/nginx/proxy.conf;
     resolver 127.0.0.11 valid=30s;
@@ -15,22 +22,5 @@ location / {
     proxy_pass http://$upstream_organizr:80;
 }
 
-location ~ /auth-(admin|user) {
-    # This is used for Organizr V1
-    internal;
-    include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
-    set $upstream_organizr organizr;
-    proxy_pass http://$upstream_organizr:80/auth.php?$1;
-    proxy_set_header Content-Length "";
-}
-
-location ~ /auth-([0-9]+) {
-    # This is used for Organizr V2
-    internal;
-    include /config/nginx/proxy.conf;
-    resolver 127.0.0.11 valid=30s;
-    set $upstream_organizr organizr;
-    proxy_pass http://$upstream_organizr:80/api/?v1/auth&group=$1;
-    proxy_set_header Content-Length "";
-}
+# enable for custom error pages
+#error_page 400 403 404 405 408 500 502 503 504 /?error=$status;

--- a/root/defaults/proxy-confs/pihole.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/pihole.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/pihole.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/pihole.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /pihole/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 
@@ -27,7 +27,7 @@ location ^~ /pihole/admin/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/plex.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/plex.subdomain.conf.sample
@@ -12,9 +12,9 @@ server {
     client_max_body_size 0;
     proxy_redirect off;
     proxy_buffering off;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
 
     location / {

--- a/root/defaults/proxy-confs/plex.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/plex.subfolder.conf.sample
@@ -1,5 +1,5 @@
 # plex does not require a base url setting
-# if plex is running in bridge mode, the below config should work as is. 
+# if plex is running in bridge mode, the below config should work as is.
 # for host mode, replace the line "proxy_pass https://$upstream_plex:32400;" with "proxy_pass https://HOSTIP:32400/web;" HOSTIP being the IP address of plex
 # in plex server settings, under network, fill in "Custom server access URLs" with your domain (ie. "https://yourdomain.url/plex:443")
 
@@ -11,7 +11,7 @@ location ^~ /plex/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/plexwebtools.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/plexwebtools.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/plexwebtools.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/plexwebtools.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /plexwebtools/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/portainer.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/portainer.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth
@@ -27,7 +27,7 @@ server {
         proxy_set_header Connection "";
         proxy_http_version 1.1;
     }
-    
+
     location /api/websocket/ {
         # enable the next two lines for http auth
         #auth_basic "Restricted";

--- a/root/defaults/proxy-confs/portainer.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/portainer.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /portainer/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/radarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/radarr.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/radarr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/radarr.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /radarr {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/rutorrent.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/rutorrent.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/rutorrent.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/rutorrent.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /rutorrent/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sabnzbd.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/sabnzbd.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/sabnzbd.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /sabnzbd {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/sickrage.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sickrage.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/sickrage.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/sickrage.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /sickrage {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/sonarr.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth
@@ -32,5 +32,5 @@ server {
         resolver 127.0.0.11 valid=30s;
         set $upstream_sonarr sonarr;
         proxy_pass http://$upstream_sonarr:8989;
-   } 
+   }
 }

--- a/root/defaults/proxy-confs/sonarr.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/sonarr.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /sonarr {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/syncthing.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/tautulli.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/tautulli.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/tautulli.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /tautulli {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/thelounge.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/thelounge.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/thelounge.subfolder.conf.sample
@@ -8,7 +8,7 @@ location ^~ /thelounge/ {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/transmission.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/transmission.subdomain.conf.sample
@@ -10,7 +10,7 @@ server {
     client_max_body_size 0;
 
     # enable for ldap auth, fill in ldap details in ldap.conf
-    #include /config/nginx/ldap.conf;
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth

--- a/root/defaults/proxy-confs/transmission.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/transmission.subfolder.conf.sample
@@ -5,7 +5,7 @@ location ^~ /transmission {
     #auth_basic "Restricted";
     #auth_basic_user_file /config/nginx/.htpasswd;
 
-    # enable the next two lines for ldap auth, also customize and enable ldap.conf in the default conf
+    # enable the next two lines for ldap auth, also customize and enable auth-confs/ldap.conf in the default conf
     #auth_request /auth;
     #error_page 401 =200 /login;
 

--- a/root/defaults/proxy-confs/unifi.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/unifi.subdomain.conf.sample
@@ -8,9 +8,9 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
-    #include /config/nginx/ldap.conf;
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
+    #include /config/nginx/auth-confs/ldap.conf;
 
     location / {
         # enable the next two lines for http auth
@@ -26,7 +26,7 @@ server {
         set $upstream_unifi unifi;
         proxy_pass https://$upstream_unifi:8443;
     }
-    
+
     location /wss {
         # enable the next two lines for http auth
         #auth_basic "Restricted";

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -35,6 +35,9 @@ mkdir -p \
 rm -rf /etc/letsencrypt
 ln -s /config/etc/letsencrypt /etc/letsencrypt
 
+# copy auth configs
+cp -R /defaults/auth-confs /config/nginx/
+
 # copy dns default configs
 cp -n /defaults/dns-conf/* /config/dns-conf/
 chown -R abc:abc /config/dns-conf


### PR DESCRIPTION
This includes a minor change to almost every proxy config just to relocate the ldap.conf to auth-confs/ldap.conf so that we can also include auth-confs/organizr.conf

The organizr auth was previously included in the organizr.subfolder.conf but this would not allow organizr auth to be used on subdomains. This new config allows use on subdomains as well.

I have also included additional notes from https://github.com/causefx/Organizr/wiki/Authentication-%7C-Server-Based#how-to-create-an-authorization-block-on-v2 regarding how to use organizr auth.

I have included organizr custom error pages in the organizr.subfolder.conf which relates to the `proxy_intercept_errors on;` line in #215 but does not depend on it (they can be used together). The placement of the `error_page` line in this file would affect all subfolder proxies if enabled. I have included this same line in the subdomain config for organizr but this would only affect that specific subdomain.

The organizr subfolder and subdomain configs include comments about enabling org auth but I have not done this to the remaining proxy configs yet (I would like to if this is an agreeable change).

I added a line to the `50-config` file to copy the auth files.