### PR TITLE
Add robots.txt subfolder proxy conf

### DIFF
--- a/root/defaults/proxy-confs/_robots.txt.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/_robots.txt.subfolder.conf.sample
@@ -1,0 +1,4 @@
+location = /robots.txt {
+    add_header Content-Type text/plain;
+    return 200 "User-agent: *\nDisallow: /\n";
+}


### PR DESCRIPTION
This is another optional config that allows people to ask search engines nicely not to index the site behind their proxy.