### PR TITLE
Add collabora online (CODE) subdomain config

### DIFF
--- a/root/defaults/proxy-confs/collabora-online.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/collabora-online.subdomain.conf.sample
@@ -1,0 +1,46 @@
+server {
+    listen 443 ssl;
+    
+    server_name office.*;
+    
+    include /config/nginx/ssl.conf;
+    
+    resolver 127.0.0.11 valid=30s;
+    set $upstream_code collabora_online.docker_reverse-proxy;
+
+     # static files
+    location ^~ /loleaflet {
+        proxy_pass https://$upstream_code:9980;
+        proxy_set_header Host $http_host;
+    }
+
+    # WOPI discovery URL
+    location ^~ /hosting/discovery {
+        proxy_pass https://$upstream_code:9980;
+        proxy_set_header Host $http_host;
+    }
+
+   # main websocket
+   location ~ ^/lool/(.*)/ws$ {
+       proxy_pass https://$upstream_code:9980;
+       proxy_set_header Upgrade $http_upgrade;
+       proxy_set_header Connection "Upgrade";
+       proxy_set_header Host $http_host;
+       proxy_read_timeout 36000s;
+   }
+   
+   # download, presentation and image upload
+   location ~ ^/lool {
+       proxy_pass https://$upstream_code:9980;
+       proxy_set_header Host $http_host;
+   }
+   
+   # Admin Console websocket
+   location ^~ /lool/adminws {
+       proxy_pass https://$upstream_code:9980;
+       proxy_set_header Upgrade $http_upgrade;
+       proxy_set_header Connection "Upgrade";
+       proxy_set_header Host $http_host;
+       proxy_read_timeout 36000s;
+   }
+} 


### PR DESCRIPTION
This PR adds a subdomain config for [Collabora Online Development Edition](https://www.collaboraoffice.com/code/) which can be integrated with Nextcloud (among other services) to provide collaborative online document editing.