### PR TITLE
Update 50-config

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -119,21 +119,21 @@ fi
 if [ -n "$SUBDOMAINS" ]; then
   echo "SUBDOMAINS entered, processing"
   if [ "$SUBDOMAINS" = "wildcard" ]; then
-    export URL_REAL="-d *.${URL} -d ${URL}"
+    export SUBDOMAINS_REAL="-d *.${URL}"
     echo "Wildcard cert for $URL will be requested"
   else
     echo "SUBDOMAINS entered, processing"
     for job in $(echo "$SUBDOMAINS" | tr "," " "); do
       export SUBDOMAINS_REAL="$SUBDOMAINS_REAL -d ${job}.${URL}"
     done
-    if [ "$ONLY_SUBDOMAINS" = true ]; then
-      URL_REAL="$SUBDOMAINS_REAL"
-      echo "Only subdomains, no URL in cert"
-    else
-      URL_REAL="-d ${URL}${SUBDOMAINS_REAL}"
-    fi
-    echo "Sub-domains processed are: $SUBDOMAINS_REAL"
   fi
+  if [ "$ONLY_SUBDOMAINS" = true ]; then
+    URL_REAL="$SUBDOMAINS_REAL"
+    echo "Only subdomains, no URL in cert"
+  else
+    URL_REAL="-d ${URL} ${SUBDOMAINS_REAL}"
+  fi
+  echo "Sub-domains processed are: $SUBDOMAINS_REAL"
 else
   echo "No subdomains defined"
   URL_REAL="-d $URL"


### PR DESCRIPTION
The current script does not allow for a wildcard cert without also getting a cert for the top level domain.  I suppose I'm one of the rare exceptions that needs that config.  This patch should fix that.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

