### PR TITLE
Add header hide to Portainer configs

### DIFF
--- a/root/defaults/proxy-confs/portainer.subdomain.conf.sample
+++ b/root/defaults/proxy-confs/portainer.subdomain.conf.sample
@@ -8,8 +8,8 @@ server {
     include /config/nginx/ssl.conf;
 
     client_max_body_size 0;
-    
-    # enable for ldap auth, fill in ldap details in ldap.conf 
+
+    # enable for ldap auth, fill in ldap details in ldap.conf
     #include /config/nginx/ldap.conf;
 
     location / {
@@ -26,8 +26,9 @@ server {
         proxy_pass http://$upstream_portainer:9000;
         proxy_set_header Connection "";
         proxy_http_version 1.1;
+        proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
     }
-    
+
     location /api/websocket/ {
         # enable the next two lines for http auth
         #auth_basic "Restricted";
@@ -43,5 +44,6 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_http_version 1.1;
+        proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
     }
 }

--- a/root/defaults/proxy-confs/portainer.subfolder.conf.sample
+++ b/root/defaults/proxy-confs/portainer.subfolder.conf.sample
@@ -17,6 +17,7 @@ location ^~ /portainer/ {
     set $upstream_portainer portainer;
     rewrite /portainer(.*) $1 break;
     proxy_pass http://$upstream_portainer:9000;
+    proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
 }
 
 location ^~ /portainer/api/websocket/ {
@@ -27,4 +28,5 @@ location ^~ /portainer/api/websocket/ {
     proxy_pass http://$upstream_portainer:9000;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_hide_header X-Frame-Options; # Possibly nott needed after Portainer 1.20.0
 }


### PR DESCRIPTION
Split from #215 
Allows Portainer behind a proxy to be loaded inside an iFrame.