### PR TITLE
Move ldap.conf to auth-confs subfolder

### DIFF
--- a/root/defaults/auth-confs/ldap.conf
+++ b/root/defaults/auth-confs/ldap.conf
@@ -1,4 +1,4 @@
-## Version 2018/08/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ldap.conf
+## Version 2018/08/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/auth-confs/ldap.conf
 ## this conf is meant to be used in conjuntction with our ldap-auth image: https://github.com/linuxserver/docker-ldap-auth
 ## see the heimdall example in the default site config for info on enabling ldap auth
 ## for further instructions on this conf, see https://github.com/nginxinc/nginx-ldap-auth

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -26,7 +26,7 @@ server {
 	include /config/nginx/ssl.conf;
 
 	# enable for ldap auth
-	#include /config/nginx/ldap.conf;
+	#include /config/nginx/auth-confs/ldap.conf;
 
 	client_max_body_size 0;
 
@@ -77,7 +77,7 @@ server {
 #}
 
 # sample reverse proxy config for "heimdall" via subdomain, with ldap authentication
-# ldap-auth container has to be running and the /config/nginx/ldap.conf file should be filled with ldap info
+# ldap-auth container has to be running and the /config/nginx/auth-confs/ldap.conf file should be filled with ldap info
 # notice this is a new server block, you need a new server block for each subdomain
 #server {
 #	listen 443 ssl http2;
@@ -90,7 +90,7 @@ server {
 #
 #	include /config/nginx/ssl.conf;
 #
-#	include /config/nginx/ldap.conf;
+#	include /config/nginx/auth-confs/ldap.conf;
 #
 #	client_max_body_size 0;
 #

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -35,6 +35,9 @@ mkdir -p \
 rm -rf /etc/letsencrypt
 ln -s /config/etc/letsencrypt /etc/letsencrypt
 
+# copy auth configs
+cp -n /defaults/auth-confs/* /config/auth-confs/
+
 # copy dns default configs
 cp -n /defaults/dns-conf/* /config/dns-conf/
 chown -R abc:abc /config/dns-conf
@@ -65,8 +68,6 @@ cp /config/fail2ban/jail.local /etc/fail2ban/jail.local
 	cp /defaults/proxy.conf /config/nginx/proxy.conf
 [[ ! -f /config/nginx/ssl.conf ]] && \
 	cp /defaults/ssl.conf /config/nginx/ssl.conf
-[[ ! -f /config/nginx/ldap.conf ]] && \
-	cp /defaults/ldap.conf /config/nginx/ldap.conf
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
 [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(cloudflare|cloudxns|digitalocean|dnsimple|dnsmadeeasy|google|luadns|nsone|ovh|rfc2136|route53)$ ]] && \


### PR DESCRIPTION
This is a follow up to #216 but only addresses moving the ldap.conf file into a subfolder. This facilitates a clear structure for additional auth configs that the user may opt to add on their own. Existing users would see the new folder and file created but their existing ldap.conf would remain in place so that their existing configs would be unaffected.

A PR for the reverse proxy repo will be created and will reference this PR.