### PR TITLE
Disable checking of client request body size in proxy

### DIFF
--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,6 +1,6 @@
 ## Version 2018/05/31 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/proxy.conf
 
-client_max_body_size 10m;
+client_max_body_size 0;
 client_body_buffer_size 128k;
 
 #Timeout if the real server is dead


### PR DESCRIPTION
https://github.com/linuxserver/docker-letsencrypt/issues/255

Default value of client_max_body_size variable is changed to 0.