### PR TITLE
shift to using the certbot version for tagging of releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM lsiobase/alpine.nginx:3.8
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG CERTBOT_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -63,10 +64,15 @@ RUN \
 	py2-future \
 	py2-pip && \
  echo "**** install certbot plugins ****" && \
+ if [ -z ${CERTBOT_VERSION+x} ]; then \
+        CERTBOT="certbot"; \
+ else \
+        CERTBOT="certbot==${CERTBOT_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	pip && \
  pip install -U --no-cache-dir \
-	certbot \
+	${CERTBOT} \
 	certbot-dns-cloudflare \
 	certbot-dns-cloudxns \
 	certbot-dns-digitalocean \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -6,6 +6,7 @@ COPY qemu-aarch64-static /usr/bin
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG CERTBOT_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -66,10 +67,15 @@ RUN \
 	py2-future \
 	py2-pip && \
  echo "**** install certbot plugins ****" && \
+ if [ -z ${CERTBOT_VERSION+x} ]; then \
+        CERTBOT="certbot"; \
+ else \
+        CERTBOT="certbot==${CERTBOT_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	pip && \
  pip install -U --no-cache-dir \
-	certbot \
+	${CERTBOT} \
 	certbot-dns-cloudflare \
 	certbot-dns-cloudxns \
 	certbot-dns-digitalocean \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -6,6 +6,7 @@ COPY qemu-arm-static /usr/bin
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG CERTBOT_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="aptalca"
 
@@ -66,10 +67,15 @@ RUN \
 	py2-future \
 	py2-pip && \
  echo "**** install certbot plugins ****" && \
+ if [ -z ${CERTBOT_VERSION+x} ]; then \
+        CERTBOT="certbot"; \
+ else \
+        CERTBOT="certbot==${CERTBOT_VERSION}"; \
+ fi && \
  pip install -U --no-cache-dir \
 	pip && \
  pip install -U --no-cache-dir \
-	certbot \
+	${CERTBOT} \
 	certbot-dns-cloudflare \
 	certbot-dns-cloudxns \
 	certbot-dns-digitalocean \

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,12 +2,13 @@
 
 # jenkins variables
 project_name: docker-letsencrypt
-external_type: os
+external_type: pip_version
 release_type: stable
 release_tag: latest
 ls_branch: master
 repo_vars:
-  - BUILD_VERSION_ARG = 'LETSENCRYPT_VERSION'
+  - EXT_PIP = 'certbot'
+  - BUILD_VERSION_ARG = 'CERTBOT_VERSION'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-letsencrypt'
   - CONTAINER_NAME = 'letsencrypt'


### PR DESCRIPTION
Once merged in enable this external trigger: 

https://ci.linuxserver.io/job/External-Triggers/job/letsencrypt-external-trigger