### PR TITLE
use python3 for certbot, clear root, clear pip cruft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,18 +63,18 @@ RUN \
 	php7-xml \
 	php7-xmlreader \
 	php7-zip \
-	py2-cryptography \
-	py2-future \
-	py2-pip && \
+	py3-cryptography \
+	py3-future \
+	py3-pip && \
  echo "**** install certbot plugins ****" && \
  if [ -z ${CERTBOT_VERSION+x} ]; then \
         CERTBOT="certbot"; \
  else \
         CERTBOT="certbot==${CERTBOT_VERSION}"; \
  fi && \
- pip install -U \
+ pip3 install -U \
 	pip && \
- pip install -U \
+ pip3 install -U \
 	${CERTBOT} \
 	certbot-dns-cloudflare \
 	certbot-dns-cloudxns \
@@ -104,8 +104,15 @@ RUN \
 	/tmp/proxy.tar.gz -C \
 	/defaults/proxy-confs --strip-components=1 --exclude=linux*/.gitattributes --exclude=linux*/.github && \
  echo "**** cleanup ****" && \
+ for cleanfiles in *.la *.pyc *.pyo; \
+	do \
+	find /usr/lib/ -iname "${cleanfiles}" -exec rm -f '{}' + \
+	; done && \
  rm -rf \
-	/tmp/*
+	/tmp/* \
+	/root && \
+ mkdir -p \
+	/root
 
 # add local files
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,9 @@ RUN \
 	/tmp/proxy.tar.gz -C \
 	/defaults/proxy-confs --strip-components=1 --exclude=linux*/.gitattributes --exclude=linux*/.github && \
  echo "**** cleanup ****" && \
- for cleanfiles in *.la *.pyc *.pyo; \
+ for cleanfiles in *.pyc *.pyo; \
 	do \
-	find /usr/lib/ -iname "${cleanfiles}" -exec rm -f '{}' + \
+	find /usr/lib/python3.*  -iname "${cleanfiles}" -exec rm -f '{}' + \
 	; done && \
  rm -rf \
 	/tmp/* \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ use python3 for certbot, as failban uses it, so no double up on python
+ clear the root cache for pip stuff (-14 MB) 
+ clear out other cruft from pip in the cleanup stage
+ test/before                latest              9c0ecad6ffed        21 minutes ago      345MB
+ test/after                 latest              399297cfab1c        2 minutes ago       246MB
+ needs testing , hence only on the x86-64 Dockerfile
+ personally only tested that it builds locally and nothing else as yet