### PR TITLE
Enabled TLS 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **10.03.19:** - Add TLSv1.3 to ssl.conf.
 * **02.03.19:** - Add php intl and posix modules.
 * **27.02.19:** - Add gnupg package.
 * **22.02.19:** - Rebase to alpine 3.9.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "10.03.19:", desc: "Add TLSv1.3 to ssl.conf." }
   - { date: "02.03.19:", desc: "Add php intl and posix modules." }
   - { date: "27.02.19:", desc: "Add gnupg package." }
   - { date: "22.02.19:", desc: "Rebase to alpine 3.9." }

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -13,7 +13,7 @@ ssl_certificate /config/keys/letsencrypt/fullchain.pem;
 ssl_certificate_key /config/keys/letsencrypt/privkey.pem;
 
 # protocols
-ssl_protocols TLSv1.2;
+ssl_protocols TLSv1.2 TLSv1.3;
 ssl_prefer_server_ciphers on;
 ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
 

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2019/01/09 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
+## Version 2019/03/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
 
 # session settings
 ssl_session_timeout 1d;


### PR DESCRIPTION
Enabled TLS version 1.3

TLS 1.3 support was added in OpenSSL 1.1.1 which was included in Apline Linux 3.9