### PR TITLE
Hash errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **07.04.19:** - Add `proxy_headers_hash_bucket_size 128;` & `proxy_headers_hash_max_size 1024;` to `proxy.conf` & `variables_hash_max_size 2048;` to `nginx.conf`  (existing users need to manually update).
 * **25.03.19:** - Rebase aarch64 image back to 3.8 due to python issues (specifically with fail2ban), switch packages to python 3 on amd64 and armhf, clean up pip/python cache to shrink image size.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **10.03.19:** - Add TLSv1.3 to ssl.conf.

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -21,7 +21,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-    variables_hash_max_size 2048;
+	variables_hash_max_size 2048;
 	
 	# server_tokens off;
 

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2018/01/29 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/nginx.conf
+## Version 2018/04/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;
@@ -21,6 +21,8 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
+    variables_hash_max_size 2048;
+	
 	# server_tokens off;
 
 	# server_names_hash_bucket_size 64;

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,4 +1,4 @@
-## Version 2019/01/21 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/proxy.conf
+## Version 2019/04/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/proxy.conf
 
 client_body_buffer_size 128k;
 
@@ -25,3 +25,5 @@ proxy_set_header Connection "";
 proxy_cache_bypass $cookie_session;
 proxy_no_cache $cookie_session;
 proxy_buffers 32 4k;
+proxy_headers_hash_bucket_size 128;
+proxy_headers_hash_max_size 1024;


### PR DESCRIPTION
Fixes these errors

```
nginx: [warn] could not build optimal proxy_headers_hash, you should increase either proxy_headers_hash_max_size: 512 or proxy_headers_hash_bucket_size: 64; ignoring proxy_headers_hash_bucket_size
```
and
```
nginx: [warn] could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
```