### PR TITLE
actually rebasing to 3.9 for aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.8
+FROM lsiobase/nginx:arm64v8-3.9
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Missed this last time