### PR TITLE
Fix urllib version

### DIFF
--- a/root/etc/cont-init.d/15-urllib
+++ b/root/etc/cont-init.d/15-urllib
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+# Fix urllib3 package
+URLLIB=$(pip show urllib3 | grep Version | cut -d' ' -f2)
+if [ ${URLLIB} != 1.24.3 ]; then
+    pip install urllib3==1.24.3 --force-reinstall
+fi


### PR DESCRIPTION
Quick and dirty fix, but easy to remove when there's a more elegant solution.

Closes https://github.com/linuxserver/docker-letsencrypt/issues/308