### PR TITLE
Add a DNS resolver for stapling so that the resolver defaults to Clou…

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **19.06.19:** - Set resolver to docker dns in ssl.conf.
 * **29.05.19:** - Compensate for changes to the reverse-proxy-confs repo.
 * **26.05.19:** - Remove botocore/urllib patch.
 * **08.05.19:** - Remove default.conf when nginx is upgraded in downstream image.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "19.06.19:", desc: "Set resolver to docker dns in ssl.conf." }
   - { date: "29.05.19:", desc: "Compensate for changes to the reverse-proxy-confs repo." }
   - { date: "26.05.19:", desc: "Remove botocore/urllib patch." }
   - { date: "08.05.19:", desc: "Remove default.conf when nginx is upgraded in downstream image." }

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -23,7 +23,8 @@ ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECD
 # OCSP Stapling
 ssl_stapling on;
 ssl_stapling_verify on;
-resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001]; # Cloudflare
+resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
+resolver_timeout 5s;
 
 # Optional additional headers
 #add_header Content-Security-Policy "upgrade-insecure-requests";

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -23,7 +23,7 @@ ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECD
 # OCSP Stapling
 ssl_stapling on;
 ssl_stapling_verify on;
-resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
+resolver 127.0.0.11 valid=300s; # Docker DNS Server
 resolver_timeout 5s;
 
 # Optional additional headers

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -23,6 +23,7 @@ ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECD
 # OCSP Stapling
 ssl_stapling on;
 ssl_stapling_verify on;
+resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001]; # Cloudflare
 
 # Optional additional headers
 #add_header Content-Security-Policy "upgrade-insecure-requests";

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -23,8 +23,7 @@ ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECD
 # OCSP Stapling
 ssl_stapling on;
 ssl_stapling_verify on;
-resolver 127.0.0.11 valid=300s; # Docker DNS Server
-resolver_timeout 5s;
+resolver 127.0.0.11 valid=30s; # Docker DNS Server
 
 # Optional additional headers
 #add_header Content-Security-Policy "upgrade-insecure-requests";

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2019/03/10 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
+## Version 2019/06/19 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
 
 # session settings
 ssl_session_timeout 1d;


### PR DESCRIPTION
…dflare

According to this website: https://sslmate.com/blog/post/ocsp_stapling_in_apache_and_nginx
"If you omit the resolver line, nginx will resolve the hostname only once, when nginx starts, using the system resolver (i.e. gethostbyname). Omitting the resolver is not recommended, since it would cause OCSP stapling to stop working if the OCSP responder's IP address changed."
