### PR TITLE
Change worker_processes value to auto

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,7 +1,7 @@
 ## Version 2018/04/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/nginx.conf
 
 user abc;
-worker_processes 4;
+worker_processes auto;
 pid /run/nginx.pid;
 include /etc/nginx/modules/*.conf;
 


### PR DESCRIPTION
The nginx documentation says (http://nginx.org/en/docs/ngx_core_module.html#worker_processes): The optimal value depends on many factors including (but not limited to) the number of CPU cores, the number of hard disk drives that store data, and load pattern. When one is in doubt, setting it to the number of available CPU cores would be a good start (the value “auto” will try to autodetect it).

So changing the "worker_processes" value to auto is more general, then the current option.