### PR TITLE
Remove redundant client_max_body_size

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -28,8 +28,6 @@ server {
 	# enable for ldap auth
 	#include /config/nginx/ldap.conf;
 
-	client_max_body_size 0;
-
 	location / {
 		try_files $uri $uri/ /index.html /index.php?$args =404;
 	}
@@ -66,8 +64,6 @@ server {
 #
 #	include /config/nginx/ssl.conf;
 #
-#	client_max_body_size 0;
-#
 #	location / {
 #		auth_basic "Restricted";
 #		auth_basic_user_file /config/nginx/.htpasswd;
@@ -91,8 +87,6 @@ server {
 #	include /config/nginx/ssl.conf;
 #
 #	include /config/nginx/ldap.conf;
-#
-#	client_max_body_size 0;
 #
 #	location / {
 #		# the next two lines will enable ldap auth along with the included ldap.conf in the server block


### PR DESCRIPTION
The `client_max_body_size` setting is defined in the `nginx.conf` file. Therefore the `default` file can be further simplified.