### PR TITLE
enable http to https redirect by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **29.07.19:** - Enable http to https redirect by default (effective only for new installs).
 * **01.07.19:** - Patch geoip2 module until upstream is fixed.
 * **30.06.19:** - Add geoip2 module.
 * **28.06.19:** - Rebasing to alpine 3.10.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "29.07.19:", desc: "Enable http to https redirect by default (effective only for new installs)." }
   - { date: "01.07.19:", desc: "Patch geoip2 module until upstream is fixed." }
   - { date: "30.06.19:", desc: "Add geoip2 module." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,13 +1,12 @@
-## Version 2018/12/05 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/default
+## Version 2019/07/29 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/default
 
-# listening on port 80 disabled by default, remove the "#" signs to enable
 # redirect all traffic to https
-#server {
-#	listen 80;
-#	listen [::]:80;
-#	server_name _;
-#	return 301 https://$host$request_uri;
-#}
+server {
+	listen 80;
+	listen [::]:80;
+	server_name _;
+	return 301 https://$host$request_uri;
+}
 
 # main server block
 server {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

