### PR TITLE
Mark https redirect block as default server

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **01.08.19:** - Mark https redirect block as default_server (effective only for new installs).
 * **31.07.19:** - Create GeoIP2 databse (libmaxminddb) during container start if it doesn't exist.
 * **30.07.19:** - Support main domain via duckdns validation.
 * **29.07.19:** - Enable http to https redirect by default (effective only for new installs).

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "01.08.19:", desc: "Mark https redirect block as default_server (effective only for new installs)." }
   - { date: "31.07.19:", desc: "Create GeoIP2 databse (libmaxminddb) during container start if it doesn't exist." }
   - { date: "30.07.19:", desc: "Support main domain via duckdns validation." }
   - { date: "29.07.19:", desc: "Enable http to https redirect by default (effective only for new installs)." }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -1,9 +1,9 @@
-## Version 2019/07/29 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/default
+## Version 2019/08/01 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/default
 
 # redirect all traffic to https
 server {
-	listen 80;
-	listen [::]:80;
+	listen 80 default_server;
+	listen [::]:80 default_server;
 	server_name _;
 	return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

