### PR TITLE
Add ssl_early_data directives

### DIFF
--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,4 +1,4 @@
-## Version 2019/04/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/proxy.conf
+## Version 2019/08/11 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/proxy.conf
 
 client_body_buffer_size 128k;
 
@@ -10,6 +10,9 @@ send_timeout 5m;
 proxy_read_timeout 240;
 proxy_send_timeout 240;
 proxy_connect_timeout 240;
+
+# TLS 1.3 early data
+proxy_set_header Early-Data $ssl_early_data;
 
 # Basic Proxy Config
 proxy_set_header Host $host:$server_port;

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2019/06/19 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
+## Version 2019/08/11 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
 
 # session settings
 ssl_session_timeout 1d;
@@ -24,6 +24,9 @@ ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECD
 ssl_stapling on;
 ssl_stapling_verify on;
 resolver 127.0.0.11 valid=30s; # Docker DNS Server
+
+# Enable TLS 1.3 early data
+ssl_early_data on;
 
 # Optional additional headers
 #add_header Content-Security-Policy "upgrade-insecure-requests";


### PR DESCRIPTION
Was reading through this https://blog.cloudflare.com/introducing-0-rtt/ a few months ago and had this branch waiting for the Alpine base image update which brought a compatible version of nginx http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data

I've tested this and it works fine. I left it enabled by default since TLS 1.3 is enabled by default as well.