### PR TITLE
Adding certbot-dns-linode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ RUN \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-google \
 	certbot-dns-inwx \
+	certbot-dns-linode \
 	certbot-dns-luadns \
 	certbot-dns-nsone \
 	certbot-dns-ovh \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -88,6 +88,7 @@ RUN \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-google \
 	certbot-dns-inwx \
+	certbot-dns-linode \
 	certbot-dns-luadns \
 	certbot-dns-nsone \
 	certbot-dns-ovh \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -88,6 +88,7 @@ RUN \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-google \
 	certbot-dns-inwx \
+	certbot-dns-linode \
 	certbot-dns-luadns \
 	certbot-dns-nsone \
 	certbot-dns-ovh \

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e URL=yourdomain.url` | Top url you have control over (`customdomain.com` if you own it, or `customsubdomain.ddnsprovider.com` if dynamic dns). |
 | `-e SUBDOMAINS=www,` | Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only) |
 | `-e VALIDATION=http` | Letsencrypt validation method to use, options are `http`, `tls-sni`, `dns` or `duckdns` (`dns` method also requires `DNSPLUGIN` variable set) (`duckdns` method requires `DUCKDNSTOKEN` variable set, and the `SUBDOMAINS` variable must be either empty or set to `wildcard`). |
-| `-e DNSPLUGIN=cloudflare` | Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `luadns`, `nsone`, `ovh`, `rfc2136` and `route53`. Also need to enter the credentials into the corresponding ini file under `/config/dns-conf`. |
+| `-e DNSPLUGIN=cloudflare` | Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `linode`, `luadns`, `nsone`, `ovh`, `rfc2136` and `route53`. Also need to enter the credentials into the corresponding ini file under `/config/dns-conf`. |
 | `-e DUCKDNSTOKEN=<token>` | Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org |
 | `-e EMAIL=<e-mail>` | Optional e-mail address used for cert expiration notifications. |
 | `-e DHLEVEL=2048` | Dhparams bit value (default=2048, can be set to `1024` or `4096`). |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ cap_add_param_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `luadns`, `nsone`, `ovh`, `rfc2136` and `route53`. Also need to enter the credentials into the corresponding ini file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `linode`, `luadns`, `nsone`, `ovh`, `rfc2136` and `route53`. Also need to enter the credentials into the corresponding ini file under `/config/dns-conf`." }
   - { env_var: "DUCKDNSTOKEN", env_value: "<token>", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "<e-mail>", desc: "Optional e-mail address used for cert expiration notifications." }
   - { env_var: "DHLEVEL", env_value: "2048", desc: "Dhparams bit value (default=2048, can be set to `1024` or `4096`)." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "12.10.19:", desc: "Add linode dns validation plugin." }
   - { date: "23.09.19:", desc: "Move GeoIP2 db to /config to make it persistent." }
   - { date: "14.08.19:", desc: "Add inwx dns validation plugin." }
   - { date: "06.08.19:", desc: "Add php7-ftp." }

--- a/root/defaults/dns-conf/linode.ini
+++ b/root/defaults/dns-conf/linode.ini
@@ -1,0 +1,3 @@
+# Instructions: https://github.com/certbot/certbot/blob/master/certbot-dns-linode/certbot_dns_linode/__init__.py#L25
+# Replace with your values
+dns_linode_key = 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ64

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -76,7 +76,7 @@ cp /config/fail2ban/jail.local /etc/fail2ban/jail.local
 	cp /defaults/ldap.conf /config/nginx/ldap.conf
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(cloudflare|cloudxns|digitalocean|dnsimple|dnsmadeeasy|google|inwx|luadns|nsone|ovh|rfc2136|route53)$ ]] && \
+[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(cloudflare|cloudxns|digitalocean|dnsimple|dnsmadeeasy|google|inwx|linode|luadns|nsone|ovh|rfc2136|route53)$ ]] && \
   echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details." && \
   sleep infinity
 


### PR DESCRIPTION
Adding support for [certbot-dns-linode](https://github.com/certbot/certbot/tree/master/certbot-dns-linode) plugin.

I tested this by building the Dockerfile on my home unraid server. It worked fine.