### PR TITLE
rootfolder

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -30,6 +30,9 @@ server {
 	client_max_body_size 0;
 
 	location / {
+		# enable rootfolder method reverse proxy confs
+		include /config/nginx/proxy-confs/*.rootfolder.conf;
+
 		try_files $uri $uri/ /index.html /index.php?$args =404;
 	}
 


### PR DESCRIPTION
https://github.com/linuxserver/reverse-proxy-confs/pull/91

The goal of this change is to simplify how users enable the Heimdall and Organizr proxy configs. Out of the box they are not setup to use subfolders but rather instruct the user to comment out the root location in the default site config in order to use the selected proxy. These changes would negate the need to change the default site config and allow users to simply rename the appropriate file. Separate subfolder proxy configs can be created to actually put Heimdall and Organizr on /heimdall and /organizr if needed.

P.S. I have tested and confirmed this works for me :tm: