### PR TITLE
Touch file in config dir when certs are changed

### DIFF
--- a/root/app/le-renew.sh
+++ b/root/app/le-renew.sh
@@ -13,7 +13,8 @@ if [ "$ORIGVALIDATION" = "dns" ] || [ "$ORIGVALIDATION" = "duckdns" ]; then
     cd /config/keys/letsencrypt && \
     openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
     sleep 1 && \
-    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem"
+    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
+    touch /config/certs-changed"
 else
   certbot -n renew \
     --pre-hook "if ps aux | grep [n]ginx: > /dev/null; then s6-svc -d /var/run/s6/services/nginx; fi" \
@@ -21,5 +22,6 @@ else
     cd /config/keys/letsencrypt && \
     openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
     sleep 1 && \
-    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem"
+    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
+    touch /config/certs-changed"
 fi


### PR DESCRIPTION
I needed a way to monitor when the certs are updated so I can then copy them to a remote server that utilizes the same certs.

I originally thought of having the le-renew.sh call a custom script during post-hook but that ran into other issues to do with ssh keys and passwords etc.

This touched file approach seemed like a fairly innocuous way of indicating to the host level that the certs have been changed. 

I run a script at the host level that watches for this file, copies the changed certs to my remote server, then removes the "certs-changed" file ready for the next update.

If you are happy with this approach I'm happy to add some documentation to the README as well.