### PR TITLE
Google Cloud DNS needs a .json for authentication

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ cap_add_param_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `linode`, `luadns`, `nsone`, `ovh`, `rfc2136`, `route53` and `transip`. Also need to enter the credentials into the corresponding ini file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `cloudflare`, `cloudxns`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `google`, `inwx`, `linode`, `luadns`, `nsone`, `ovh`, `rfc2136`, `route53` and `transip`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "DUCKDNSTOKEN", env_value: "<token>", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "<e-mail>", desc: "Optional e-mail address used for cert expiration notifications." }
   - { env_var: "DHLEVEL", env_value: "2048", desc: "Dhparams bit value (default=2048, can be set to `1024` or `4096`)." }
@@ -81,7 +81,7 @@ app_setup_block: |
   * Before running this container, make sure that the url and subdomains are properly forwarded to this container's host, and that port 443 (and/or 80) is not being used by another service on the host (NAS gui, another webserver, etc.).
   * For `http` validation, port 80 on the internet side of the router should be forwarded to this container's port 80
   * For `tls-sni` validation, port 443 on the internet side of the router should be forwarded to this container's port 443
-  * For `dns` validation, make sure to enter your credentials into the corresponding ini file under `/config/dns-conf`
+  * For `dns` validation, make sure to enter your credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`
     * Cloudflare provides free accounts for managing dns and is very easy to use with this image. Make sure that it is set up for "dns only" instead of "dns + proxy"
     * Google dns plugin is meant to be used with "Google Cloud DNS", a paid enterprise product, and not for "Google Domains DNS"
   * For `duckdns` validation, either leave the `SUBDOMAINS` variable empty or set it to `wildcard`, and set the `DUCKDNSTOKEN` variable with your duckdns token. Due to a limitation of duckdns, the resulting cert will only cover either main subdomain (ie. `yoursubdomain.duckdns.org`), or sub-subdomains (ie. `*.yoursubdomain.duckdns.org`), but will not both at the same time. You can use our [duckdns image](https://hub.docker.com/r/linuxserver/duckdns/) to update your IP on duckdns.org.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -126,6 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "11.12.19:", desc: "Fix Google Cloud DNS to use .json file for authentication." }
   - { date: "20.11.19:", desc: "Fix cryptography version mismatch due to pip issue." }
   - { date: "17.11.19:", desc: "Add php7-pdo_odbc." }
   - { date: "17.11.19:", desc: "Add transip dns validation plugin." }

--- a/root/defaults/dns-conf/google.ini
+++ b/root/defaults/dns-conf/google.ini
@@ -1,6 +1,0 @@
-# Intructions: https://github.com/certbot/certbot/blob/master/certbot-dns-google/certbot_dns_google/__init__.py
-# Replace with your values
-{
-  "type": "service_account",
-  ...
-}

--- a/root/defaults/dns-conf/google.json
+++ b/root/defaults/dns-conf/google.json
@@ -1,0 +1,6 @@
+{
+  "instructions": "https://github.com/certbot/certbot/blob/master/certbot-dns-google/certbot_dns_google/__init__.py",
+  "_comment": "Replace with your values",
+  "type": "service_account",
+  "rest": "..."
+}

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -174,6 +174,8 @@ fi
 if [ "$VALIDATION" = "dns" ]; then
   if [ "$DNSPLUGIN" = "route53" ]; then
     PREFCHAL="--dns-${DNSPLUGIN} --manual-public-ip-logging-ok"
+  elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
+    PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json --manual-public-ip-logging-ok --dns-${DNSPLUGIN}-propagation-seconds 120"
   elif [[ "$DNSPLUGIN" =~ ^(inwx|transip)$ ]]; then
     PREFCHAL="-a certbot-dns-${DNSPLUGIN}:dns-${DNSPLUGIN} --certbot-dns-${DNSPLUGIN}:dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini --manual-public-ip-logging-ok"
   else
@@ -224,6 +226,13 @@ fi
 # saving new variables
 echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\"" > /config/donoteditthisfile.conf
 
+# alter extension for error message
+if [ "$DNSPLUGIN" = "google" ]; then
+  FILENAME="$DNSPLUGIN.json"
+else
+  FILENAME="$DNSPLUGIN.ini"
+fi
+
 # generating certs if necessary
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   echo "Generating new certificate"
@@ -233,7 +242,7 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
     cd /config/keys/letsencrypt || exit
   else
     if [ "$VALIDATION" = "dns" ]; then
-      echo "ERROR: Cert does not exist! Please see the validation error above. Make sure you entered correct credentials into the /config/dns-conf/${DNSPLUGIN}.ini file."
+      echo "ERROR: Cert does not exist! Please see the validation error above. Make sure you entered correct credentials into the /config/dns-conf/${FILENAME} file."
     elif [ "$VALIDATION" = "duckdns" ]; then
       echo "ERROR: Cert does not exist! Please see the validation error above. Make sure your DUCKDNSTOKEN is correct."
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
GCP Google Cloud DNS cannot authenticate when using a `.ini` file with service account credentials.
As stated in [Certbot Google DNS Documentation](https://certbot-dns-google.readthedocs.io/en/stable/), it is looking for a `.json` file.
[Certbot Documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options) also states it is looking for a `.json` file, compared to other plugins that state it is looking for a `.ini` file.

When using the `.ini` file, the container produces the following error:
```
Encountered exception during recovery:
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/certbot/_internal/error_handler.py", line 124, in _call_registered
    self.funcs[-1]()
  File "/usr/lib/python3.7/site-packages/certbot/_internal/auth_handler.py", line 243, in _cleanup_challenges
    self.auth.cleanup(achalls)
  File "/usr/lib/python3.7/site-packages/certbot/plugins/dns_common.py", line 77, in cleanup
    self._cleanup(domain, validation_domain_name, validation)
  File "/usr/lib/python3.7/site-packages/certbot_dns_google/_internal/dns_google.py", line 73, in _cleanup
    self._get_google_client().del_txt_record(domain, validation_name, validation, self.ttl)
  File "/usr/lib/python3.7/site-packages/certbot_dns_google/_internal/dns_google.py", line 76, in _get_google_client
    return _GoogleClient(self.conf('credentials'))
  File "/usr/lib/python3.7/site-packages/certbot_dns_google/_internal/dns_google.py", line 88, in __init__
    credentials = ServiceAccountCredentials.from_json_keyfile_name(account_json, scopes)
  File "/usr/lib/python3.7/site-packages/oauth2client/service_account.py", line 220, in from_json_keyfile_name
    client_credentials = json.load(file_obj)
  File "/usr/lib/python3.7/json/__init__.py", line 296, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
An unexpected error occurred:
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
Please see the logfiles in /var/log/letsencrypt for more details.
ERROR: Cert does not exist! Please see the validation error above. Make sure you entered correct credentials into the /config/dns-conf/google.ini file.
```

When using a `.json` file, the container produces the following:
```
Obtaining a new certificate
Performing the following challenges:
dns-01 challenge for domain.app
dns-01 challenge for domain.app
URL being requested: GET https://www.googleapis.com/discovery/v1/apis/dns/v1/rest
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones?dnsName=domain.app.&alt=json
Attempting refresh to obtain initial access_token
Refreshing access_token
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/rrsets?alt=json
URL being requested: POST https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/88?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/88?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/88?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/88?alt=json
URL being requested: GET https://www.googleapis.com/discovery/v1/apis/dns/v1/rest
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones?dnsName=domain.app.&alt=json
Attempting refresh to obtain initial access_token
Refreshing access_token
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/rrsets?alt=json
URL being requested: POST https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/89?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/89?alt=json
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes/89?alt=json
Waiting 120 seconds for DNS changes to propagate
Waiting for verification...
Cleaning up challenges
URL being requested: GET https://www.googleapis.com/discovery/v1/apis/dns/v1/rest
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones?dnsName=domain.app.&alt=json
Attempting refresh to obtain initial access_token
Refreshing access_token
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/rrsets?alt=json
URL being requested: POST https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes?alt=json
URL being requested: GET https://www.googleapis.com/discovery/v1/apis/dns/v1/rest
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones?dnsName=domain.app.&alt=json
Attempting refresh to obtain initial access_token
Refreshing access_token
URL being requested: GET https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/rrsets?alt=json
URL being requested: POST https://dns.googleapis.com/dns/v1/projects/domain-projects/managedZones/123123123123123/changes?alt=json
IMPORTANT NOTES:
 - Congratulations! Your certificate and chain have been saved at:
   /etc/letsencrypt/live/domain.app/fullchain.pem
   Your key file has been saved at:
   /etc/letsencrypt/live/domain.app/privkey.pem
   Your cert will expire on 2020-03-10. To obtain a new or tweaked
   version of this certificate in the future, simply run certbot
   again. To non-interactively renew *all* of your certificates, run
   "certbot renew"
 - If you like Certbot, please consider supporting our work by:

   Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
   Donating to EFF:                    https://eff.org/donate-le

New certificate generated; starting nginx
creating GeoIP2 database
[cont-init.d] 50-config: exited 0.
[cont-init.d] 99-custom-files: executing...
[custom-init] no custom files found exiting...
[cont-init.d] 99-custom-files: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
nginx: [alert] detected a LuaJIT version which is not OpenResty's; many optimizations will be disabled and performance will be compromised (see https://github.com/openresty/luajit2 for OpenResty's LuaJIT or, even better, consider using the OpenResty releases from https://openresty.org/en/download.html)
Server ready
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Accepting this PR will allow users to correctly authenticate against Google Cloud DNS.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally building with code changes, and verifying that GCP Cloud DNS managed zone saw the TXT records being created and removed.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
[Certbot Documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options)
[Certbot Google DNS Documentation](https://certbot-dns-google.readthedocs.io/en/stable/)