### PR TITLE
Update ciphers

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -119,13 +119,14 @@ app_setup_block: |
   * You can check which jails are active via `docker exec -it letsencrypt fail2ban-client status`
   * You can check the status of a specific jail via `docker exec -it letsencrypt fail2ban-client status <jail name>`
   * You can unban an IP via `docker exec -it letsencrypt fail2ban-client set <jail name> unbanip <IP>`
-  * A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands  
+  * A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands
 
 app_setup_nginx_reverse_proxy_snippet: false
 app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "07.01.20:", desc: "Update ciphers from Mozilla ssl-config recommendations." }
   - { date: "01.01.20:", desc: "Add support for gandi dns validation." }
   - { date: "31.12.19:", desc: "GeoIP2 databases now require personal license keys to download. Auto download is disabled and log message is added." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -13,9 +13,10 @@ ssl_certificate /config/keys/letsencrypt/fullchain.pem;
 ssl_certificate_key /config/keys/letsencrypt/privkey.pem;
 
 # protocols
+# using generated 2020-01-07, https://ssl-config.mozilla.org/#server=nginx&server-version=1.16.1-r4&config=intermediate&openssl-version=1.1.1d-r3
 ssl_protocols TLSv1.2 TLSv1.3;
-ssl_prefer_server_ciphers on;
-ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+ssl_prefer_server_ciphers off;
 
 # HSTS, remove # from the line below to enable HSTS
 #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2019/08/11 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
+## Version 2020/01/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
 
 # session settings
 ssl_session_timeout 1d;


### PR DESCRIPTION
Added a comment line with https://ssl-config.mozilla.org/#server=nginx&server-version=1.16.1-r4&config=intermediate&openssl-version=1.1.1d-r3 and the generated date. The version numbers in the URL for this commit are https://github.com/linuxserver/docker-letsencrypt/blob/1ce415aed417be6fe6ad94365262e2718c34fb56/package_versions.txt#L99 and https://github.com/linuxserver/docker-letsencrypt/blob/1ce415aed417be6fe6ad94365262e2718c34fb56/package_versions.txt#L120

Updated ciphers to match the recommendations from the `intermediate` config (which has been previously used as the source for updates to the ciphers).

`ssl_prefer_server_ciphers` previously did not have a recommendation from the mozilla config, but they now recommend it to be `off`.