### PR TITLE
Fix upstream auth vars

### DIFF
--- a/root/defaults/ldap.conf
+++ b/root/defaults/ldap.conf
@@ -1,4 +1,4 @@
-## Version 2020/03/05 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ldap.conf
+## Version 2020/03/13 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ldap.conf
 ## this conf is meant to be used in conjuntction with our ldap-auth image: https://github.com/linuxserver/docker-ldap-auth
 ## see the heimdall example in the default site config for info on enabling ldap auth
 ## for further instructions on this conf, see https://github.com/nginxinc/nginx-ldap-auth

--- a/root/defaults/ldap.conf
+++ b/root/defaults/ldap.conf
@@ -5,19 +5,19 @@
 
     location /login {
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app ldap-auth;
-        set $upstream_port 9000;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        set $upstream_auth_app ldap-auth;
+        set $upstream_auth_port 9000;
+        set $upstream_auth_proto http;
+        proxy_pass $upstream_auth_proto://$upstream_auth_app:$upstream_auth_port;
         proxy_set_header X-Target $request_uri;
     }
 
     location = /auth {
         resolver 127.0.0.11 valid=30s;
-        set $upstream_app ldap-auth;
-        set $upstream_port 8888;
-        set $upstream_proto http;
-        proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+        set $upstream_auth_app ldap-auth;
+        set $upstream_auth_port 8888;
+        set $upstream_auth_proto http;
+        proxy_pass $upstream_auth_proto://$upstream_auth_app:$upstream_auth_port;
 
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";


### PR DESCRIPTION
When using `auth_request` the variables from the parent proxy are conflicting and causing 404 errors.

Ref: https://github.com/linuxserver/reverse-proxy-confs/pull/138