### PR TITLE
Give Digital Ocean a longer propagation time

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -174,6 +174,8 @@ fi
 if [ "$VALIDATION" = "dns" ]; then
   if [ "$DNSPLUGIN" = "route53" ]; then
     PREFCHAL="--dns-${DNSPLUGIN} --manual-public-ip-logging-ok"
+  elif [ "$DNSPLUGIN" = "digitalocean" ]; then
+    PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini --manual-public-ip-logging-ok --dns-${DNSPLUGIN}-propagation-seconds 120"
   elif [[ "$DNSPLUGIN" =~ ^(cpanel)$ ]]; then
     PREFCHAL="-a certbot-dns-${DNSPLUGIN}:${DNSPLUGIN} --certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini --manual-public-ip-logging-ok --certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-propagation-seconds 120"
   elif [[ "$DNSPLUGIN" =~ ^(gandi)$ ]]; then
@@ -241,7 +243,7 @@ fi
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   echo "Generating new certificate"
  # shellcheck disable=SC2086
- certbot certonly --dns-digitalocean-propagation-seconds 120 --renew-by-default --server $ACMESERVER $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+ certbot certonly --renew-by-default --server $ACMESERVER $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
   if [ -d /config/keys/letsencrypt ]; then
     cd /config/keys/letsencrypt || exit
   else

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -241,7 +241,7 @@ fi
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   echo "Generating new certificate"
  # shellcheck disable=SC2086
- certbot certonly --renew-by-default --server $ACMESERVER $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+ certbot certonly --dns-digitalocean-propagation-seconds 120 --renew-by-default --server $ACMESERVER $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
   if [ -d /config/keys/letsencrypt ]; then
     cd /config/keys/letsencrypt || exit
   else


### PR DESCRIPTION
I have given digital ocean a 2 minute propagation time.

My script was continuously failing because of "Incorrect TXT record", the TXT record it found in the log was always the previous value of the txt record. After updating the record, it seemed to check too quickly and get the previous instead of new value.

After setting it to two minutes, it has worked every time.
