### PR TITLE
fail2ban support for deny statements

### DIFF
--- a/root/defaults/fail2ban/filter.d/nginx-deny.conf
+++ b/root/defaults/fail2ban/filter.d/nginx-deny.conf
@@ -1,0 +1,15 @@
+# fail2ban filter configuration for nginx
+
+
+[Definition]
+
+
+failregex = ^ \[error\] \d+#\d+: \*\d+ (access forbidden by rule), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP\/\d+\.\d+", host: "\S+"(?:, referrer: "\S+")?\s*$
+
+ignoreregex =
+
+datepattern = {^LN-BEG}
+
+# DEV NOTES:
+#
+# Author: Will L (driz@linuxserver.io)

--- a/root/defaults/jail.local
+++ b/root/defaults/jail.local
@@ -48,3 +48,10 @@ enabled  = true
 port     = http,https
 filter   = nginx-botsearch
 logpath  = /config/log/nginx/access.log
+
+[nginx-deny]
+
+enabled  = true
+port     = http,https
+filter   = nginx-deny
+logpath  = /config/log/nginx/error.log


### PR DESCRIPTION
fail2ban filter for nginx deny statements

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
add a custom filter to handle nginx deny statements

## Benefits of this PR and context:
because we discuss allow and deny statements with users but don't offer a way for fail2ban to react to them. sadly, the default configs also don't handle deny statements (i should probably submit a PR)

## How Has This Been Tested?
from logs (these are actual attempt to intrude on my stuff, not created by me for testing.)
```
2020/05/08 12:22:24 [error] 403#403: *16830 access forbidden by rule, client: 209.17.96.250, server: transmission.*, request: "GET / HTTP/1.1", host: "transmission.mydomain.com"
2020/05/08 13:05:53 [error] 403#403: *17379 access forbidden by rule, client: 209.17.96.210, server: heimdall.*, request: "GET / HTTP/1.1", host: "heimdall.mydomain.com"
```
and test
```
fail2ban-regex /config/log/nginx/error.log /config/fail2ban/filter.d/nginx-deny.conf

Running tests
=============

Use   failregex filter file : nginx-deny, basedir: /config/fail2ban
Use      datepattern : Default Detectors
Use         log file : /config/log/nginx/error.log
Use         encoding : UTF-8


Results
=======

Failregex: 109 total
|-  #) [# of hits] regular expression
|   1) [109] ^ \[error\] \d+#\d+: \*\d+ (access forbidden by rule), client: <HOST>, server: \S*, request: "\S+ \S+ HTTP\/\d+\.\d+", host: "\S+"(?:, referrer: "\S+")?\s*$
`-

Ignoreregex: 0 total

Date template hits:
|- [# of hits] date format
|  [231] {^LN-BEG}ExYear(?P<_sep>[-/.])Month(?P=_sep)Day(?:T|  ?)24hour:Minute:Second(?:[.,]Microseconds)?(?:\s*Zone offset)?
`-

Lines: 231 lines, 0 ignored, 109 matched, 122 missed
[processed in 0.02 sec]

Missed line(s): too many to print.  Use --print-all-missed to print all 122 lines
```

as you can see, it picked up 109 matches (the log was rotated just today)
