### PR TITLE
Add directive to make OCSP stapling work (and give positive yes on ss…

### DIFF
--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -24,7 +24,8 @@ ssl_prefer_server_ciphers off;
 # OCSP Stapling
 ssl_stapling on;
 ssl_stapling_verify on;
-resolver 127.0.0.11 valid=30s; # Docker DNS Server
+ssl_trusted_certificate /config/keys/letsencrypt/fullchain.pem;
+resolver 8.8.8.8 1.1.1.1 ; # Use public DNS servers
 
 # Enable TLS 1.3 early data
 ssl_early_data on;


### PR DESCRIPTION
This PR adds the nginx directive

ssl_trusted_certificate /config/keys/letsencrypt/fullchain.pem;

in ssl.conf and switches the resolver to use publicly available DNS resolvers (because the default "docker DNS one wasn't working at all in any of my tests". It uses two different public DNS resolvers on two different networks. 

Using these changes "OCSP Stapling: Yes" appears on ssllabs.com tests whereas with the previous config it would report "No" under stapling. 