### PR TITLE
Reformat ssl.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,9 @@ RUN \
 	/defaults/proxy-confs --strip-components=1 --exclude=linux*/.gitattributes --exclude=linux*/.github --exclude=linux*/.gitignore --exclude=linux*/LICENSE && \
  echo "**** configure nginx ****" && \
  rm -f /etc/nginx/conf.d/default.conf && \
+ curl -o \
+	/defaults/dhparams.pem -L \
+	"https://lsio.ams3.digitaloceanspaces.com/dhparams.pem" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -131,6 +131,9 @@ RUN \
 	/defaults/proxy-confs --strip-components=1 --exclude=linux*/.gitattributes --exclude=linux*/.github --exclude=linux*/.gitignore --exclude=linux*/LICENSE && \
  echo "**** configure nginx ****" && \
  rm -f /etc/nginx/conf.d/default.conf && \
+ curl -o \
+	/defaults/dhparams.pem -L \
+	"https://lsio.ams3.digitaloceanspaces.com/dhparams.pem" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -131,6 +131,9 @@ RUN \
 	/defaults/proxy-confs --strip-components=1 --exclude=linux*/.gitattributes --exclude=linux*/.github --exclude=linux*/.gitignore --exclude=linux*/LICENSE && \
  echo "**** configure nginx ****" && \
  rm -f /etc/nginx/conf.d/default.conf && \
+ curl -o \
+	/defaults/dhparams.pem -L \
+	"https://lsio.ams3.digitaloceanspaces.com/dhparams.pem" && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ docker create \
   -e PROPAGATION= `#optional` \
   -e DUCKDNSTOKEN= `#optional` \
   -e EMAIL= `#optional` \
-  -e DHLEVEL=2048 `#optional` \
   -e ONLY_SUBDOMAINS=false `#optional` \
   -e EXTRA_DOMAINS= `#optional` \
   -e STAGING=false `#optional` \
@@ -110,7 +109,6 @@ services:
       - PROPAGATION= #optional
       - DUCKDNSTOKEN= #optional
       - EMAIL= #optional
-      - DHLEVEL=2048 #optional
       - ONLY_SUBDOMAINS=false #optional
       - EXTRA_DOMAINS= #optional
       - STAGING=false #optional
@@ -140,7 +138,6 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PROPAGATION=` | Optionally override (in seconds) the default propagation time for the dns plugins. |
 | `-e DUCKDNSTOKEN=` | Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org |
 | `-e EMAIL=` | Optional e-mail address used for cert expiration notifications. |
-| `-e DHLEVEL=2048` | Dhparams bit value (default=2048, can be set to `1024` or `4096`). |
 | `-e ONLY_SUBDOMAINS=false` | If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true` |
 | `-e EXTRA_DOMAINS=` | Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org` |
 | `-e STAGING=false` | Set to `true` to retrieve certs in staging mode. Rate limits will be much higher, but the resulting cert will not pass the browser's security test. Only to be used for testing purposes. |
@@ -192,7 +189,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 * After setup, navigate to `https://yourdomain.url` to access the default homepage (http access through port 80 is disabled by default, you can enable it by editing the default site config at `/config/nginx/site-confs/default`).
 * Certs are checked nightly and if expiration is within 30 days, renewal is attempted. If your cert is about to expire in less than 30 days, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing. It is recommended to input your e-mail in docker parameters so you receive expiration notices from letsencrypt in those circumstances.
 ### Security and password protection
-* The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. It also detects changes to the DHLEVEL parameter and replaces the dhparams file.
+* The container detects changes to url and subdomains, revokes existing certs and generates new ones during start.
 * If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file `docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd <username>`
 * You can add multiple user:pass to `.htpasswd`. For the first user, use the above command, for others, use the above command without the `-c` flag, as it will force deletion of the existing `.htpasswd` and creation of a new one
 * You can also use ldap auth for security and access control. A sample, user configurable ldap.conf is provided, and it requires the separate image [linuxserver/ldap-auth](https://hub.docker.com/r/linuxserver/ldap-auth/) to communicate with an ldap server.
@@ -295,6 +292,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **17.06.20:** - Reformat ssl.conf. Pull in pre-generated 4096-bit dhparams.pem from DO Spaces (rotated weekly via Jenkins job: https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity for use in new instances); deprecate `DHLEVEL` param.
 * **01.06.20:** - Rebasing to alpine 3.12, change ldap login address to `/ldaplogin` to avoid clashes (existing users need to manually update).
 * **31.05.20:** - Tweak Authelia confs (existing users can delete `authelia-server.conf` and `authelia-location.conf`, and restart to update).
 * **23.05.20:** - Add support for Authelia.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 * Certs are checked nightly and if expiration is within 30 days, renewal is attempted. If your cert is about to expire in less than 30 days, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing. It is recommended to input your e-mail in docker parameters so you receive expiration notices from letsencrypt in those circumstances.
 ### Security and password protection
 * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start.
+* The container provides a pre-generated 4096-bit dhparams.pem (rotated weekly via [Jenkins job](https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity)) for new instances, however you may generate your own by running `docker exec letsencrypt openssl dhparam -out /config/nginx/dhparams.pem 4096` WARNING: This takes a very long time
 * If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file `docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd <username>`
 * You can add multiple user:pass to `.htpasswd`. For the first user, use the above command, for others, use the above command without the `-c` flag, as it will force deletion of the existing `.htpasswd` and creation of a new one
 * You can also use ldap auth for security and access control. A sample, user configurable ldap.conf is provided, and it requires the separate image [linuxserver/ldap-auth](https://hub.docker.com/r/linuxserver/ldap-auth/) to communicate with an ldap server.
@@ -292,7 +293,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **17.06.20:** - Reformat ssl.conf. Pull in pre-generated 4096-bit dhparams.pem from DO Spaces (rotated weekly via Jenkins job: https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity for use in new instances); deprecate `DHLEVEL` param.
+* **17.06.20:** - Reformat ssl.conf. Pull in pre-generated dhparams.pem from DO Spaces. Deprecate `DHLEVEL` param.
 * **01.06.20:** - Rebasing to alpine 3.12, change ldap login address to `/ldaplogin` to avoid clashes (existing users need to manually update).
 * **31.05.20:** - Tweak Authelia confs (existing users can delete `authelia-server.conf` and `authelia-location.conf`, and restart to update).
 * **23.05.20:** - Add support for Authelia.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -127,6 +127,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "17.06.20:", desc: "Reformat ssl.conf." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12, change ldap login address to `/ldaplogin` to avoid clashes (existing users need to manually update)." }
   - { date: "31.05.20:", desc: "Tweak Authelia confs (existing users can delete `authelia-server.conf` and `authelia-location.conf`, and restart to update)." }
   - { date: "23.05.20:", desc: "Add support for Authelia." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -55,7 +55,6 @@ opt_param_env_vars:
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications." }
-  - { env_var: "DHLEVEL", env_value: "2048", desc: "Dhparams bit value (default=2048, can be set to `1024` or `4096`)." }
   - { env_var: "ONLY_SUBDOMAINS", env_value: "false", desc: "If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`" }
   - { env_var: "EXTRA_DOMAINS", env_value: "", desc: "Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`" }
   - { env_var: "STAGING", env_value: "false", desc: "Set to `true` to retrieve certs in staging mode. Rate limits will be much higher, but the resulting cert will not pass the browser's security test. Only to be used for testing purposes." }
@@ -90,7 +89,7 @@ app_setup_block: |
   * After setup, navigate to `https://yourdomain.url` to access the default homepage (http access through port 80 is disabled by default, you can enable it by editing the default site config at `/config/nginx/site-confs/default`).
   * Certs are checked nightly and if expiration is within 30 days, renewal is attempted. If your cert is about to expire in less than 30 days, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing. It is recommended to input your e-mail in docker parameters so you receive expiration notices from letsencrypt in those circumstances.
   ### Security and password protection
-  * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start. It also detects changes to the DHLEVEL parameter and replaces the dhparams file.
+  * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start.
   * If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file `docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd <username>`
   * You can add multiple user:pass to `.htpasswd`. For the first user, use the above command, for others, use the above command without the `-c` flag, as it will force deletion of the existing `.htpasswd` and creation of a new one
   * You can also use ldap auth for security and access control. A sample, user configurable ldap.conf is provided, and it requires the separate image [linuxserver/ldap-auth](https://hub.docker.com/r/linuxserver/ldap-auth/) to communicate with an ldap server.
@@ -127,7 +126,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
-  - { date: "17.06.20:", desc: "Reformat ssl.conf." }
+  - { date: "17.06.20:", desc: "Reformat ssl.conf. Pull in pre-generated 4096-bit dhparams.pem from DO Spaces (rotated weekly via Jenkins job: https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity for use in new instances); deprecate `DHLEVEL` param." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12, change ldap login address to `/ldaplogin` to avoid clashes (existing users need to manually update)." }
   - { date: "31.05.20:", desc: "Tweak Authelia confs (existing users can delete `authelia-server.conf` and `authelia-location.conf`, and restart to update)." }
   - { date: "23.05.20:", desc: "Add support for Authelia." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -90,6 +90,7 @@ app_setup_block: |
   * Certs are checked nightly and if expiration is within 30 days, renewal is attempted. If your cert is about to expire in less than 30 days, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing. It is recommended to input your e-mail in docker parameters so you receive expiration notices from letsencrypt in those circumstances.
   ### Security and password protection
   * The container detects changes to url and subdomains, revokes existing certs and generates new ones during start.
+  * The container provides a pre-generated 4096-bit dhparams.pem (rotated weekly via [Jenkins job](https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity)) for new instances, however you may generate your own by running `docker exec letsencrypt openssl dhparam -out /config/nginx/dhparams.pem 4096` WARNING: This takes a very long time
   * If you'd like to password protect your sites, you can use htpasswd. Run the following command on your host to generate the htpasswd file `docker exec -it letsencrypt htpasswd -c /config/nginx/.htpasswd <username>`
   * You can add multiple user:pass to `.htpasswd`. For the first user, use the above command, for others, use the above command without the `-c` flag, as it will force deletion of the existing `.htpasswd` and creation of a new one
   * You can also use ldap auth for security and access control. A sample, user configurable ldap.conf is provided, and it requires the separate image [linuxserver/ldap-auth](https://hub.docker.com/r/linuxserver/ldap-auth/) to communicate with an ldap server.
@@ -126,7 +127,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
-  - { date: "17.06.20:", desc: "Reformat ssl.conf. Pull in pre-generated 4096-bit dhparams.pem from DO Spaces (rotated weekly via Jenkins job: https://ci.linuxserver.io/blue/organizations/jenkins/Xtras-Builders-Etc%2Fdhparams-uploader/activity for use in new instances); deprecate `DHLEVEL` param." }
+  - { date: "17.06.20:", desc: "Reformat ssl.conf. Pull in pre-generated dhparams.pem from DO Spaces. Deprecate `DHLEVEL` param." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12, change ldap login address to `/ldaplogin` to avoid clashes (existing users need to manually update)." }
   - { date: "31.05.20:", desc: "Tweak Authelia confs (existing users can delete `authelia-server.conf` and `authelia-location.conf`, and restart to update)." }
   - { date: "23.05.20:", desc: "Add support for Authelia." }

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,33 +1,42 @@
-## Version 2020/01/07 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
+## Version 2020/06/17 - Changelog: https://github.com/linuxserver/docker-letsencrypt/commits/master/root/defaults/ssl.conf
 
-# session settings
+### Mozilla Recommendations
+# generated 2020-06-17, Mozilla Guideline v5.4, nginx 1.18.0-r0, OpenSSL 1.1.1g-r0, intermediate configuration
+# https://ssl-config.mozilla.org/#server=nginx&version=1.18.0-r0&config=intermediate&openssl=1.1.1g-r0&guideline=5.4ssl_protocols TLSv1.2 TLSv1.3;
+
 ssl_session_timeout 1d;
-ssl_session_cache shared:SSL:50m;
+ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions
 ssl_session_tickets off;
 
-# Diffie-Hellman parameter for DHE cipher suites
-ssl_dhparam /config/nginx/dhparams.pem;
-
-# ssl certs
-ssl_certificate /config/keys/letsencrypt/fullchain.pem;
-ssl_certificate_key /config/keys/letsencrypt/privkey.pem;
-
-# protocols
-# using generated 2020-01-07, https://ssl-config.mozilla.org/#server=nginx&server-version=1.16.1-r4&config=intermediate&openssl-version=1.1.1d-r3
+# intermediate configuration
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
 ssl_prefer_server_ciphers off;
 
-# HSTS, remove # from the line below to enable HSTS
-#add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-
-# OCSP Stapling
+# OCSP stapling
 ssl_stapling on;
 ssl_stapling_verify on;
+
+
+### Linuxserver.io Defaults
+
+# Certificates
+ssl_certificate /config/keys/letsencrypt/fullchain.pem;
+ssl_certificate_key /config/keys/letsencrypt/privkey.pem;
+# verify chain of trust of OCSP response using Root CA and Intermediate certs
+ssl_trusted_certificate /config/keys/letsencrypt/fullchain.pem;
+
+# Diffie-Hellman Parameters
+ssl_dhparam /config/nginx/dhparams.pem;
+
+# Resolver
 resolver 127.0.0.11 valid=30s; # Docker DNS Server
 
 # Enable TLS 1.3 early data
 ssl_early_data on;
+
+# HSTS, remove # from the line below to enable HSTS
+#add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
 # Optional additional headers
 #add_header Content-Security-Policy "upgrade-insecure-requests";

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -2,7 +2,7 @@
 
 ### Mozilla Recommendations
 # generated 2020-06-17, Mozilla Guideline v5.4, nginx 1.18.0-r0, OpenSSL 1.1.1g-r0, intermediate configuration
-# https://ssl-config.mozilla.org/#server=nginx&version=1.18.0-r0&config=intermediate&openssl=1.1.1g-r0&guideline=5.4ssl_protocols TLSv1.2 TLSv1.3;
+# https://ssl-config.mozilla.org/#server=nginx&version=1.18.0-r0&config=intermediate&openssl=1.1.1g-r0&guideline=5.4
 
 ssl_session_timeout 1d;
 ssl_session_cache shared:MozSSL:10m;  # about 40000 sessions

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -9,7 +9,6 @@ URL=${URL}\\n\
 SUBDOMAINS=${SUBDOMAINS}\\n\
 EXTRA_DOMAINS=${EXTRA_DOMAINS}\\n\
 ONLY_SUBDOMAINS=${ONLY_SUBDOMAINS}\\n\
-DHLEVEL=${DHLEVEL}\\n\
 VALIDATION=${VALIDATION}\\n\
 DNSPLUGIN=${DNSPLUGIN}\\n\
 EMAIL=${EMAIL}\\n\
@@ -21,7 +20,7 @@ if [ -n "${TEST_RUN}" ]; then
 fi
 
 # Sanitize variables
-SANED_VARS=( DHLEVEL DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION )
+SANED_VARS=( DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION )
 for i in "${SANED_VARS[@]}"
 do
   export echo "$i"="${!i//\"/}"
@@ -46,8 +45,8 @@ chown -R abc:abc /config/dns-conf
 
 # copy reverse proxy configs
 cp -R /defaults/proxy-confs /config/nginx/
-# remove outdated files (remove this action after 2019/08/29)
-rm -f /config/nginx/proxy-confs/_readme /config/nginx/proxy-confs/mytinytodo.subfolder.conf.example
+# remove outdated files (remove this action after 2020/10/17)
+rm -f /config/nginx/proxy-confs/seafile.subdomain.config.sample /config/nginx/proxy-confs/librespeed.subdomain.com.sample
 
 # copy/update the fail2ban config defaults to/in /config
 cp -R /defaults/fail2ban/filter.d /config/fail2ban/
@@ -79,6 +78,17 @@ cp /config/fail2ban/jail.local /etc/fail2ban/jail.local
 [[ ! -f /config/nginx/authelia-location.conf ]] && \
 	cp /defaults/authelia-location.conf /config/nginx/authelia-location.conf
 
+# copy pre-generated dhparams or generate if needed
+[[ ! -f /config/nginx/dhparams.pem ]] && \
+  cp /defaults/dhparams.pem /config/nginx/dhparams.pem
+if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
+  curl -o /config/nginx/dhparams.pem -L "https://lsio.ams3.digitaloceanspaces.com/dhparams.pem"
+fi
+if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
+  echo "Generating dhparams.pem. This will take a long time. Do not stop the container until this process is completed."
+  openssl dhparam -out /config/nginx/dhparams.pem 4096
+fi
+
 # check to make sure DNSPLUGIN is selected if dns validation is used
 [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|cloudflare|cloudxns|cpanel|digitalocean|dnsimple|dnsmadeeasy|domeneshop|gandi|google|inwx|linode|luadns|nsone|ovh|rfc2136|route53|transip)$ ]] && \
   echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details." && \
@@ -90,7 +100,7 @@ cp /config/crontabs/* /etc/crontabs/
 
 # create original config file if it doesn't exist
 if [ ! -f "/config/donoteditthisfile.conf" ]; then
-  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\"" > /config/donoteditthisfile.conf
+  echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\"" > /config/donoteditthisfile.conf
   echo "Created donoteditthisfile.conf"
 fi
 
@@ -104,26 +114,12 @@ if [ -z "$VALIDATION" ]; then
   echo "VALIDATION parameter not set; setting it to http"
 fi
 
-# compare dhparams existence and level, create if necessary
-if [ ! "$DHLEVEL" = "$ORIGDHLEVEL" ]; then
-  rm -rf /config/nginx/dhparams.pem
-  echo "DH parameters bit setting changed. Deleting old dhparams file."
-fi
-
 # if staging is set to true, use the staging server
 if [ "$STAGING" = "true" ]; then
   echo "NOTICE: Staging is active"
   ACMESERVER="https://acme-staging-v02.api.letsencrypt.org/directory"
 else
   ACMESERVER="https://acme-v02.api.letsencrypt.org/directory"
-fi
-
-if [ ! -f "/config/nginx/dhparams.pem" ]; then
-  echo "Creating DH parameters for additional security. This may take a very long time. There will be another message once this process is completed"
-  openssl dhparam -out /config/nginx/dhparams.pem "$DHLEVEL"
-  echo "DH parameters successfully created - $DHLEVEL bits"
-else
-  echo "$ORIGDHLEVEL bit DH parameters present"
 fi
 
 # figuring out url only vs url & subdomains vs subdomains only
@@ -238,7 +234,7 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGDHLEVEL=\"$DHLEVEL\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\"" > /config/donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\"" > /config/donoteditthisfile.conf
 
 # alter extension for error message
 if [ "$DNSPLUGIN" = "google" ]; then


### PR DESCRIPTION
More clarity on which settings are Mozilla Recommendations vs Linuxserver.io defaults
Add `ssl_trusted_certificate` (brought up in https://github.com/linuxserver/docker-letsencrypt/pull/461 and is also part of the Mozilla spec)
Include Mozilla Guideline version so we know when it needs to be updated

Side notes:
Moved HSTS to the bottom near the optional header lines. This puts anything we expect the user to enable all at the bottom.