### PR TITLE
Adding explicit wildcard to $EXTRA_DOMAINS in docs/README

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -56,7 +56,7 @@ opt_param_env_vars:
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications." }
   - { env_var: "ONLY_SUBDOMAINS", env_value: "false", desc: "If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`" }
-  - { env_var: "EXTRA_DOMAINS", env_value: "", desc: "Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org`" }
+  - { env_var: "EXTRA_DOMAINS", env_value: "", desc: "Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org,*.anotherdomain.org`" }
   - { env_var: "STAGING", env_value: "false", desc: "Set to `true` to retrieve certs in staging mode. Rate limits will be much higher, but the resulting cert will not pass the browser's security test. Only to be used for testing purposes." }
 opt_param_usage_include_vols: false
 opt_param_volumes:


### PR DESCRIPTION
## Description:
`$EXTRA_DOMAINS` supports wildcards. Adding to the examples to make this explicit.

## Benefits of this PR and context:
It wasn't immediately intuitive that I could use wildcards in `$EXTRA_DOMAINS` – so this ought to negate any questions about this.

Basically, just making sure the docs/README cover a case that feels like it might be more common than a corner-case.

Might also make sense to add comments about how one could look at the [`certbot` documentation][certbot-docs] for more info – which I'm willing to do, though I'd appreciate being pointed in the right direction. If [this is the right place][certbot-mention-tack-d], then I can knock that out this afternoon. (Although this is for Webroot, not necessarily `nginx`.)

[certbot-docs]: https://certbot.eff.org/docs/
[certbot-mention-tack-d]: https://certbot.eff.org/docs/using.html#webroot

## How Has This Been Tested?
I've tested this on my own setup and certs appear to be valid (using Brave, Chrome, Firefox, and Safari as well as their "Private/Incognito Modes"). Testing involved navigating to the subdomains covered by `$URL`, then the wildcards covered by `$EXTRA_DOMAINS`.

Just for good measure, a snippet of my `docker-compose.yml`:
```yaml
services:
  letsencrypt:
    # ...
    environmnet:
      URL: domain.com
      SUBDOMAINS: wildard
      EXTRA_DOMAINS: >
        *.sub1.domain.com,
        *.sub2.domain.com
    # ...
```

## Source / References:
Via Discord: https://discord.com/channels/354974912613449730/354974913049919488/736268903843627049
